### PR TITLE
[#24] 에러 관리 시스템 추가

### DIFF
--- a/packages/app/src/features/auth/errors.ts
+++ b/packages/app/src/features/auth/errors.ts
@@ -1,0 +1,5 @@
+import Errors from '@/types/Errors'
+
+const errors: Errors = {}
+
+export default errors

--- a/packages/app/src/features/auth/service/login.ts
+++ b/packages/app/src/features/auth/service/login.ts
@@ -1,12 +1,12 @@
 import { serverApi } from '@api'
-import { isAxiosError } from 'axios'
+import ErrorMapper from '@lib/ErrorMapper'
+import errors from '@features/auth/errors'
 
 const login = async (code: string) => {
   try {
     await serverApi.post('/auth', { code })
   } catch (e) {
-    if (!isAxiosError(e)) alert('알 수 없는 에러 발생')
-    alert('관리자 문의 ㄱㄱ')
+    alert(ErrorMapper(e, errors))
   }
 }
 

--- a/packages/app/src/lib/ErrorMapper.ts
+++ b/packages/app/src/lib/ErrorMapper.ts
@@ -1,0 +1,30 @@
+import { isAxiosError } from 'axios'
+import Errors from '@/types/Errors'
+
+const ErrorMapper = (e: unknown, errors: Errors) => {
+  const unknownMessage =
+    '알 수 없는 에러가 발생했습니다.\n관리자에게 문의해 주세요.'
+
+  if (
+    !isAxiosError(e) ||
+    !e.config ||
+    !e.config.baseURL ||
+    !e.config.url ||
+    !e.config.method ||
+    !e.status
+  )
+    return unknownMessage
+
+  try {
+    const message =
+      errors[e.config.baseURL][e.config.url][e.config.method.toUpperCase()]
+
+    if (!message[e.status] && !message['*']) return unknownMessage
+
+    return message[e.status] ?? message['*']
+  } catch {
+    return unknownMessage
+  }
+}
+
+export default ErrorMapper

--- a/packages/app/src/lib/env.ts
+++ b/packages/app/src/lib/env.ts
@@ -1,7 +1,7 @@
 if (
   !(
-    process.env.NEXT_PUBLIC_GAUTH_REDIRECT_URI ||
-    process.env.NEXT_PUBLIC_GAUTH_CLIENT_ID ||
+    process.env.NEXT_PUBLIC_GAUTH_REDIRECT_URI &&
+    process.env.NEXT_PUBLIC_GAUTH_CLIENT_ID &&
     process.env.NEXT_PUBLIC_SERVER_URL
   )
 )

--- a/packages/app/src/types/Errors.ts
+++ b/packages/app/src/types/Errors.ts
@@ -1,0 +1,12 @@
+interface Errors {
+  [baseUrl: string]: {
+    [url: string]: {
+      [method: string]: {
+        [status: number]: string
+        '*'?: string
+      }
+    }
+  }
+}
+
+export default Errors


### PR DESCRIPTION
## 💡 개요

errorMapper를 통해 에러 메시지를 관리하는 기능 추가

## 📃 작업내용

- errorMapper를 통한 에러 메시지 관리 시스템 도입
- 기존 로그인 기능의 에러 메시지 띄우는 방식을 errorMapper로 변경

## 🍴 사용방법

- errorMapper에 error 객체와 Errors 타입의 객체를 넣어주면 에러 메시지가 나오는 형태이다

- Errors 타입의 객체는 아래와 같은 형식이다

```ts
interface Errors {
  [baseUrl: string]: {
    [url: string]: {
      [method: string]: {
        [status: number]: string
        '*'?: string
      }
    }
  }
}
```

## 🎸 기타

alert도 만들어야 할 듯...