### PR TITLE
[#49] select options prop 수정

### DIFF
--- a/packages/shared/src/atoms/Select/index.stories.ts
+++ b/packages/shared/src/atoms/Select/index.stories.ts
@@ -1,5 +1,23 @@
 import { Meta, StoryObj } from '@storybook/react'
 import Select from './index'
+import type { OptionsType } from './type'
+
+const options = [
+  'hi',
+  'hello',
+  'woeijfwoiefjweoijf',
+  'jfowejfowiejfowjgoh',
+  'not',
+  'ur',
+  'wefoijoi',
+  'friends',
+  'wefohijof',
+  'fwowefjw',
+  'woefjweoijf',
+].reduce((pre, cur) => {
+  pre[cur] = cur
+  return pre
+}, {} as OptionsType)
 
 const config: Meta<typeof Select> = {
   title: 'Select',
@@ -7,19 +25,7 @@ const config: Meta<typeof Select> = {
   args: {
     name: 'hi',
     register: () => {},
-    options: [
-      'hi',
-      'hello',
-      'woeijfwoiefjweoijf',
-      'jfowejfowiejfowjgoh',
-      'not',
-      'ur',
-      'wefoijoi',
-      'friends',
-      'wefohijof',
-      'fwowefjw',
-      'woefjweoijf',
-    ],
+    options,
   },
 }
 

--- a/packages/shared/src/atoms/Select/index.tsx
+++ b/packages/shared/src/atoms/Select/index.tsx
@@ -1,16 +1,18 @@
 import { MouseEvent, useEffect, useRef, useState } from 'react'
 import { ArrowDown } from '../../icons'
 import * as S from './style'
+import { OptionsType } from './type'
 
 interface Props {
-  options: string[]
+  options: OptionsType
   register: any
   name: string
 }
 
 const Select = ({ options, name, register }: Props) => {
   const [isShow, setIsShow] = useState<boolean>(false)
-  const [value, setValue] = useState<string>(options[0])
+  const optionKeys = Object.keys(options)
+  const [value, setValue] = useState<string>(options[optionKeys[0]])
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -44,21 +46,21 @@ const Select = ({ options, name, register }: Props) => {
       <S.SelectedOption>{value}</S.SelectedOption>
       <ArrowDown />
       <S.Options isShow={isShow} onClick={onShow}>
-        {options?.map((option, idx) => (
+        {optionKeys.map((key, idx) => (
           <S.Option
             htmlFor={`${name}-${idx}`}
-            onClick={() => onClick(option)}
-            key={option}
+            onClick={() => onClick(options[key])}
+            key={key}
           >
             <S.CheckButton
               {...register(name)}
               id={`${name}-${idx}`}
               name={name}
-              value={option}
-              defaultChecked={value === option}
+              value={options[key]}
+              defaultChecked={value === options[key]}
               type='radio'
             />
-            {option}
+            {options[key]}
           </S.Option>
         ))}
       </S.Options>

--- a/packages/shared/src/atoms/Select/type.ts
+++ b/packages/shared/src/atoms/Select/type.ts
@@ -1,3 +1,7 @@
+export interface OptionsType {
+  [key: string]: string
+}
+
 export interface OptionsProps {
   isShow: boolean
 }

--- a/packages/shared/src/atoms/index.ts
+++ b/packages/shared/src/atoms/index.ts
@@ -9,3 +9,5 @@ export { default as Chip } from './Chip'
 export { default as Profile } from './Profile'
 export { default as Select } from './Select'
 export { default as FileInput } from './FileInput'
+
+export type { OptionsType } from './Select/type'


### PR DESCRIPTION
## 💡 개요

select의 options prop의 타입을 수정합니다

## 📃 작업내용

이전에는 string[]로 받았지만 현재는 아래와 같이 받는다

```ts
export interface OptionsType {
  [key: string]: string
}
```

## 🔀 변경사항

string[] -> { [key: string]: string }

## 🍴 사용방법

```tsx
import { Select } from '@sms/shared'

const Component = () => {
   const options = { key: 'value' }
   return <Select options={options} register={() => {}} name='test' />
}
```

## 🎸 기타

OptionsType을 atoms/index.ts에서 export하고 있다
그 이유는 reduce를 통해서 string[]를 변환할 때 OptionsType이 자주 사용 될 것 같아서 export 하기로 했다