### PR TITLE
[#53] 외국어 입력폼 추가

### DIFF
--- a/packages/shared/.eslintrc.cjs
+++ b/packages/shared/.eslintrc.cjs
@@ -2,5 +2,6 @@ module.exports = {
   extends: ['../../.eslintrc.js'],
   rules: {
     'no-restricted-imports': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
   },
 }

--- a/packages/shared/src/molecules/MultiDoubleInput/index.stories.tsx
+++ b/packages/shared/src/molecules/MultiDoubleInput/index.stories.tsx
@@ -1,0 +1,35 @@
+import { Meta } from '@storybook/react'
+import { useForm } from 'react-hook-form'
+import React from 'react'
+import MultiDoubleInput from './index'
+
+const config: Meta<typeof MultiDoubleInput> = {
+  title: 'MultiDoubleInput',
+  component: MultiDoubleInput,
+}
+
+export default config
+
+interface FormType {
+  item: {
+    languageCertificateName: string
+    score: string
+  }
+}
+
+export const Primary = () => {
+  const { register, control, handleSubmit } = useForm<FormType>()
+
+  const onSubmit = (_form: FormType) => {}
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <MultiDoubleInput
+        name={'item' as const}
+        register={register}
+        control={control}
+      />
+      <button type='submit'>submit</button>
+    </form>
+  )
+}

--- a/packages/shared/src/molecules/MultiDoubleInput/index.tsx
+++ b/packages/shared/src/molecules/MultiDoubleInput/index.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from 'react'
+import {
+  Control,
+  FieldValues,
+  UseFormRegister,
+  useFieldArray,
+} from 'react-hook-form'
+import { Trash } from '../../icons'
+import { Chip, Input } from '../../atoms'
+import * as S from './style'
+
+interface Props {
+  name: string
+  control: Control<any>
+  register: UseFormRegister<any>
+}
+
+const MultiDoubleInput = ({ name, control, register }: Props) => {
+  const { fields, append, remove } = useFieldArray<FieldValues>({
+    name,
+    control,
+  })
+
+  useEffect(() => {
+    append({})
+  }, [])
+
+  return (
+    <S.Wrapper>
+      <S.InputsWrapper>
+        {fields.map((field, index) => (
+          <S.InputWrapper key={field.id}>
+            <S.DoubleInputWrapper>
+              <Input
+                {...register(`${name}[${index}].languageCertificateName`)}
+                placeholder='예) 토익'
+              />
+              <Input
+                {...register(`${name}[${index}].score`)}
+                placeholder='990'
+              />
+            </S.DoubleInputWrapper>
+
+            {fields.length > 1 && (
+              <S.RemoveBtn type='button' onClick={() => remove(index)}>
+                <Trash />
+              </S.RemoveBtn>
+            )}
+          </S.InputWrapper>
+        ))}
+      </S.InputsWrapper>
+      <Chip onClick={() => append('')}>추가</Chip>
+    </S.Wrapper>
+  )
+}
+
+export default MultiDoubleInput

--- a/packages/shared/src/molecules/MultiDoubleInput/style.ts
+++ b/packages/shared/src/molecules/MultiDoubleInput/style.ts
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled'
+
+export const Wrapper = styled.div`
+  width: 100%;
+`
+
+export const InputsWrapper = styled.div`
+  width: 100%;
+  margin-bottom: 0.5rem;
+`
+
+export const InputWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`
+
+export const DoubleInputWrapper = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  gap: 1rem;
+`
+
+export const RemoveBtn = styled.button`
+  background: transparent;
+  border: none;
+  cursor: pointer;
+`

--- a/packages/shared/src/molecules/index.ts
+++ b/packages/shared/src/molecules/index.ts
@@ -1,1 +1,2 @@
 export { default as MultiInput } from './MultiInput'
+export { default as MultiDoubleInput } from './MultiDoubleInput'


### PR DESCRIPTION
## 💡 개요

외국어 입력폼을 보면 input이 2개씩 늘어나는 걸 볼 수 있다
때문에 따로 구현을 했다

## 📃 작업내용

https://github.com/GSM-MSG/SMS-FrontEnd/assets/57276315/71a64e18-255b-470c-a85e-495d3a20367d

## 🔀 변경사항

shared에서는 eslint의 no-any 옵션이 꺼지게 변경

## 🍴 사용방법

```tsx
import { MultiDoubleInput } from '@sms/shared'

interface FormType {
  item: { // props로 전달할 name과 같게 해야함
    languageCertificateName: string // 이 필드명은 고정임
    score: string // 이 필드명은 고정임
  }
}

const Component = () => {
  const { register, control, handleSubmit } = useForm<FormType>()

  const onSubmit = (_form: FormType) => {}

  return (
    <form onSubmit={handleSubmit(onSubmit)}>
      <MultiDoubleInput
        name={'item'} // FormType의 필드명과 같게 해야함
        register={register}
        control={control}
      />
      <button type='submit'>submit</button>
    </form>
  )
}
```