### PR TITLE
[#60] input의 reset 기능

### DIFF
--- a/packages/shared/src/atoms/Input/index.tsx
+++ b/packages/shared/src/atoms/Input/index.tsx
@@ -49,7 +49,6 @@ const Input = forwardRef<HTMLInputElement, Props>(
           />
           <S.ResetButton
             style={{ opacity: props.value || value ? 1 : 0 }}
-            type='reset'
             onClick={onReset}
           >
             <Xmark />

--- a/packages/shared/src/atoms/Input/index.tsx
+++ b/packages/shared/src/atoms/Input/index.tsx
@@ -15,10 +15,11 @@ interface Props
     HTMLInputElement
   > {
   error?: string
+  isReset?: boolean
 }
 
 const Input = forwardRef<HTMLInputElement, Props>(
-  ({ error, ...props }, ref) => {
+  ({ error, isReset, ...props }, ref) => {
     const [value, setValue] = useState<string>('')
     const [isFocused, setIsFocused] = useState<boolean>(false)
     const inputRef = useRef<HTMLInputElement>(null)
@@ -48,7 +49,9 @@ const Input = forwardRef<HTMLInputElement, Props>(
             ref={ref ? ref : inputRef}
           />
           <S.ResetButton
-            style={{ opacity: props.value || value ? 1 : 0 }}
+            style={{
+              display: isReset && (props.value || value) ? 'block' : 'none',
+            }}
             onClick={onReset}
           >
             <Xmark />

--- a/packages/shared/src/atoms/Input/style.ts
+++ b/packages/shared/src/atoms/Input/style.ts
@@ -5,14 +5,14 @@ export const Wrapper = styled.div`
   width: 100%;
 `
 
-export const InputWrapper = styled.form<InputWrapperProps>`
-  min-width: 12.5rem;
+export const InputWrapper = styled.label<InputWrapperProps>`
   padding: 0.8rem 0.75rem;
   border-radius: 0.5rem;
   margin-bottom: 0.5rem;
   display: flex;
   background: var(--N10);
   transition: 0.2s;
+  cursor: text;
 
   border: 1px solid
     ${({ isFocused }) => (isFocused ? 'var(--P2)' : 'transparent')};


### PR DESCRIPTION
## 💡 개요

- input의 reset 기능을 활성화 또는 비활성화 할 수 있게 했습니다
- 기존 공간을 차지하던 reset button을 완전히 없애게 변경했습니다

## 🍴 사용방법

```tsx
import { Input } from '@sms/shared'

const Component = () => {
   return (
      <Input isReset /> // 이렇게 하면 reset 기능이 활성화됨
   )
}
```
