### PR TITLE
[#72] 직접 입력 선택 기능 추가

### DIFF
--- a/packages/shared/src/atoms/Select/index.stories.tsx
+++ b/packages/shared/src/atoms/Select/index.stories.tsx
@@ -49,6 +49,7 @@ export const Primary = () => {
         register={register}
         options={options}
         control={control}
+        directInput
       />
       <button type='submit'>submit</button>
     </form>

--- a/packages/shared/src/atoms/Select/index.tsx
+++ b/packages/shared/src/atoms/Select/index.tsx
@@ -10,9 +10,10 @@ interface Props {
   register: any
   control: Control<any>
   name: string
+  directInput?: boolean
 }
 
-const Select = ({ options, name, register, control }: Props) => {
+const Select = ({ options, name, register, control, directInput }: Props) => {
   const [isShow, setIsShow] = useState<boolean>(false)
   const optionKeys = Object.keys(options)
   const [value, setValue] = useState<string>(options[optionKeys[0]])
@@ -74,16 +75,18 @@ const Select = ({ options, name, register, control }: Props) => {
             />
           ))}
 
-          <S.Option>
-            <S.CheckButton
-              onClick={() => setDirectIsChecked(true)}
-              {...register(name)}
-              name={name}
-              value={''}
-              type='radio'
-            />
-            직접 입력
-          </S.Option>
+          {directInput && (
+            <S.Option>
+              <S.CheckButton
+                onClick={() => setDirectIsChecked(true)}
+                {...register(name)}
+                name={name}
+                value={''}
+                type='radio'
+              />
+              직접 입력
+            </S.Option>
+          )}
         </S.Options>
       </S.SelectWrapper>
 


### PR DESCRIPTION
## 💡 개요

직접 입력을 선택적으로 추가할 수 있는 기능을 추가했습니다

## 📃 작업내용

directInput이라는 props를 boolean 값으로 넘겨 받게 하고
directInput이 true면 직접 입력이 활성화 되도록 변경했습니다

## 🍴 사용방법

```tsx
interface FormType {
  select: string
}


const Component = () => {
  const { register, handleSubmit, control } = useForm<FormType>()

  const onSubmit = handleSubmit(() => {})

  return (
    <form onSubmit={onSubmit}>
      <Select
        name='select'
        register={register}
        options={options}
        control={control}
        directInput // 요고 추가함
      />
      <button type='submit'>submit</button>
    </form>
  )
}
```