### PR TITLE
[#77] 로그인 페이지 기능 추가 및 반응형 수정

### DIFF
--- a/packages/app/src/features/auth/components/GuestLink.tsx
+++ b/packages/app/src/features/auth/components/GuestLink.tsx
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled'
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+interface Props {
+  href: string
+  children: ReactNode
+}
+
+const Wrapper = styled(Link)`
+  ${({ theme }) => theme.body2}
+  color: var(--WHITE);
+  text-decoration: underline;
+  display: block;
+  text-align: center;
+  margin-top: 1rem;
+  cursor: pointer;
+`
+
+const GuestLink = ({ children, href }: Props) => {
+  return <Wrapper href={href}>{children}</Wrapper>
+}
+
+export default GuestLink

--- a/packages/app/src/features/auth/components/index.ts
+++ b/packages/app/src/features/auth/components/index.ts
@@ -1,0 +1,1 @@
+export { default as GuestLink } from './GuestLink'

--- a/packages/app/src/templates/LoginTemplate/index.tsx
+++ b/packages/app/src/templates/LoginTemplate/index.tsx
@@ -1,5 +1,6 @@
 import { FadeinAnimation, GauthLoginButton, Headline, Title } from '@sms/shared'
 import useAuth from '@features/auth/hook/useAuth'
+import { GuestLink } from '@features/auth/components'
 import * as S from './style'
 
 const LoginTemplate = () => {
@@ -25,6 +26,8 @@ const LoginTemplate = () => {
       </FadeinAnimation>
       <FadeinAnimation duration={1.6}>
         <GauthLoginButton onClick={onClick} />
+
+        <GuestLink href='/'>게스트로 둘러보기</GuestLink>
       </FadeinAnimation>
     </S.Wrapper>
   )

--- a/packages/app/src/templates/LoginTemplate/style.ts
+++ b/packages/app/src/templates/LoginTemplate/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 
 export const Wrapper = styled.main`
-  margin-top: 8rem;
+  padding-top: 8rem;
   width: 100%;
   height: 100vh;
   display: flex;


### PR DESCRIPTION
## 💡 개요

로그인 페이지에서 메인 페이지로 갈 수 있게 하는 기능을 추가했습니다

<img width="539" alt="image" src="https://github.com/GSM-MSG/SMS-FrontEnd/assets/57276315/ced4e8e0-e6fe-4773-b171-91d517c45fa0">

로그인 페이지의 반응형에 문제가 있어 수정했습니다

<img width="404" alt="image" src="https://github.com/GSM-MSG/SMS-FrontEnd/assets/57276315/da96defa-0729-48e6-baf2-a07bd0d0217d">

## 📃 작업내용

- `GuestLink` 컴포넌트를 추가해 메인페이지로 갈 수 있게 하는 기능을 추가했습니다
- margin으로 콘텐츠를 밀어내서 발생한 이슈를 padding으로 변경했습니다