### PR TITLE
[#76] title 에러 픽스

### DIFF
--- a/packages/app/src/components/SEO/index.tsx
+++ b/packages/app/src/components/SEO/index.tsx
@@ -16,7 +16,7 @@ const SEO = ({
 }: Props) => {
   return (
     <Head>
-      <title>SMS{title && ` | ${title}`}</title>
+      <title>{`SMS${title && ` | ${title}`}`}</title>
 
       <meta
         name='keywords'


### PR DESCRIPTION
## 💡 개요

seo를 추가한 이후로 아래와 같은 에러가 발생해서 수정했습니다

```
Warning: A title element received an array with more than 1 element as children. In browsers title Elements can only have Text Nodes as children. If the children being rendered output more than a single text node in aggregate the browser will display markup and comments as text in the title and hydration will likely fail and fall back to client rendering
```

## 📃 작업내용

title 태그의 value값을 수정했습니다

## 🎸 기타

[참고 자료](https://velog.io/@xmun74/A-title-element-received-an-array-with-more-than-1-element-as-children)