### PR TITLE
[#91] 토큰 재발급 및 토큰 할당 로직 추가

### DIFF
--- a/packages/app/src/api/CustomBaseQuery.ts
+++ b/packages/app/src/api/CustomBaseQuery.ts
@@ -1,0 +1,24 @@
+import { BaseQueryFn, FetchBaseQueryMeta } from '@reduxjs/toolkit/query/react'
+import { AxiosError, AxiosRequestConfig, isAxiosError } from 'axios'
+import axiosApi from './axiosApi'
+
+const CutomBaseQuery: BaseQueryFn<
+  AxiosRequestConfig,
+  unknown,
+  AxiosError | string,
+  object, // TODO 이게 뭐지??
+  FetchBaseQueryMeta
+> = async (args) => {
+  try {
+    const res = await axiosApi({
+      ...args,
+    })
+
+    return { data: res.data }
+  } catch (error) {
+    if (!isAxiosError(error)) return { error: String(error) }
+    return { error }
+  }
+}
+
+export default CutomBaseQuery

--- a/packages/app/src/api/axiosApi.ts
+++ b/packages/app/src/api/axiosApi.ts
@@ -1,6 +1,23 @@
 import axios from 'axios'
 import env from '@lib/env'
+import TokenManager from '@lib/TokenManager'
+import needsTokenRefresh from '@lib/needsTokenRefresh'
 
 const axiosApi = axios.create({ baseURL: env.NEXT_PUBLIC_SERVER_URL })
+
+axiosApi.interceptors.request.use(async (config) => {
+  const tokenManager = new TokenManager()
+
+  let isSuccessed = true
+
+  if (needsTokenRefresh(config.url, config.method))
+    isSuccessed = await tokenManager.reissueToken()
+
+  if (!isSuccessed) return { ...config, signal: AbortSignal.abort() }
+
+  config.headers['Authorization'] = `Bearer ${tokenManager.accessToken}`
+
+  return config
+})
 
 export default axiosApi

--- a/packages/app/src/api/axiosApi.ts
+++ b/packages/app/src/api/axiosApi.ts
@@ -15,7 +15,9 @@ axiosApi.interceptors.request.use(async (config) => {
 
   if (!isSuccessed) return { ...config, signal: AbortSignal.abort() }
 
-  config.headers['Authorization'] = `Bearer ${tokenManager.accessToken}`
+  config.headers['Authorization'] = tokenManager.accessToken
+    ? `Bearer ${tokenManager.accessToken}`
+    : undefined
 
   return config
 })

--- a/packages/app/src/api/rtkApi.ts
+++ b/packages/app/src/api/rtkApi.ts
@@ -1,8 +1,8 @@
-import env from '@lib/env'
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { createApi } from '@reduxjs/toolkit/query/react'
+import CutomBaseQuery from './CustomBaseQuery'
 
 const rtkApi = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: env.NEXT_PUBLIC_SERVER_URL }),
+  baseQuery: CutomBaseQuery,
   endpoints: () => ({}),
 })
 

--- a/packages/app/src/features/auth/service/login.ts
+++ b/packages/app/src/features/auth/service/login.ts
@@ -1,10 +1,13 @@
 import { axiosApi } from '@api'
 import ErrorMapper from '@lib/ErrorMapper'
 import errors from '@features/auth/errors'
+import { TokenResponse } from '@features/auth/type/TokenResponse'
+import TokenManager from '@lib/TokenManager'
 
 const login = async (code: string) => {
   try {
-    await axiosApi.post('/auth', { code })
+    const { data } = await axiosApi.post<TokenResponse>('/auth', { code })
+    TokenManager.setToken(data)
   } catch (e) {
     alert(ErrorMapper(e, errors))
   }

--- a/packages/app/src/features/auth/service/reissue.ts
+++ b/packages/app/src/features/auth/service/reissue.ts
@@ -1,0 +1,22 @@
+import { ReissueResponse } from '@features/auth/type/TokenResponse'
+import axios from 'axios'
+
+const reissue = async (refreshToken: string) => {
+  try {
+    const { data } = await axios.patch<ReissueResponse>(
+      '/auth',
+      {},
+      {
+        headers: {
+          'Refresh-Token': refreshToken,
+        },
+      }
+    )
+
+    return data
+  } catch (e) {
+    return
+  }
+}
+
+export default reissue

--- a/packages/app/src/features/auth/type/TokenResponse.ts
+++ b/packages/app/src/features/auth/type/TokenResponse.ts
@@ -1,0 +1,10 @@
+export interface TokenResponse {
+  accessToken: string
+  refreshToken: string
+  accessTokenExp: string
+  refreshTokenExp: string
+  role: 'ROLE_STUDENT' | 'ROLE_TEACHER'
+  isExist: boolean
+}
+
+export type ReissueResponse = Omit<TokenResponse, 'isExist' | 'role'>

--- a/packages/app/src/lib/Observable.ts
+++ b/packages/app/src/lib/Observable.ts
@@ -1,0 +1,22 @@
+type Callback = (value: boolean) => void
+
+class Observable {
+  private _observers: Callback[] = []
+
+  setOvserver(observer: Callback) {
+    this._observers.push(observer)
+  }
+
+  notifyAll(isSuccessed: boolean) {
+    this._observers.forEach((observer) => observer(isSuccessed))
+    this._observers = []
+  }
+
+  get observers() {
+    return this._observers
+  }
+}
+
+const observable = new Observable()
+
+export default observable

--- a/packages/app/src/lib/Token.ts
+++ b/packages/app/src/lib/Token.ts
@@ -1,0 +1,8 @@
+enum Token {
+  ACCESS_TOKEN = 'accessToken',
+  REFRESH_TOKEN = 'refreshToken',
+  ACCESS_TOKEN_EXP = 'accessTokenExp',
+  REFRESH_TOKEN_EXP = 'refreshTokenExp',
+}
+
+export default Token

--- a/packages/app/src/lib/TokenManager.ts
+++ b/packages/app/src/lib/TokenManager.ts
@@ -1,6 +1,7 @@
 import reissue from '@features/auth/service/reissue'
 import { ReissueResponse } from '@features/auth/type/TokenResponse'
 import Token from './Token'
+import observable from './Observable'
 
 class TokenManager {
   accessToken: string | null = null
@@ -51,10 +52,22 @@ class TokenManager {
     )
       return false
 
+    if (!observable.observers.length) {
+      return new Promise<boolean>((resolve) => {
+        observable.setOvserver(resolve)
+      })
+    }
+
+    observable.setOvserver((_value) => {})
     const data = await reissue(this.refreshToken)
-    if (!data) return false
+
+    if (!data) {
+      observable.notifyAll(false)
+      return false
+    }
 
     TokenManager.setToken(data)
+    observable.notifyAll(true)
 
     return true
   }

--- a/packages/app/src/lib/TokenManager.ts
+++ b/packages/app/src/lib/TokenManager.ts
@@ -1,0 +1,69 @@
+import reissue from '@features/auth/service/reissue'
+import { ReissueResponse } from '@features/auth/type/TokenResponse'
+import Token from './Token'
+
+class TokenManager {
+  accessToken: string | null = null
+  refreshToken: string | null = null
+  accessTokenExp: Date | null = null
+  refreshTokenExp: Date | null = null
+
+  constructor() {
+    this.setTokenFromLocalStorage()
+  }
+
+  static setToken(tokens: ReissueResponse) {
+    localStorage.setItem(Token.ACCESS_TOKEN, tokens.accessToken)
+    localStorage.setItem(Token.REFRESH_TOKEN, tokens.refreshToken)
+    localStorage.setItem(Token.ACCESS_TOKEN_EXP, tokens.accessTokenExp)
+    localStorage.setItem(Token.REFRESH_TOKEN_EXP, tokens.refreshTokenExp)
+  }
+
+  static clearToken() {
+    localStorage.removeItem(Token.ACCESS_TOKEN)
+    localStorage.removeItem(Token.REFRESH_TOKEN)
+    localStorage.removeItem(Token.ACCESS_TOKEN_EXP)
+    localStorage.removeItem(Token.REFRESH_TOKEN_EXP)
+  }
+
+  setTokenFromLocalStorage() {
+    if (typeof window === 'undefined') return
+
+    this.accessToken = localStorage.getItem(Token.ACCESS_TOKEN)
+    this.refreshToken = localStorage.getItem(Token.REFRESH_TOKEN)
+    this.accessTokenExp = new Date(
+      localStorage.getItem(Token.ACCESS_TOKEN_EXP) || ''
+    )
+    this.refreshTokenExp = new Date(
+      localStorage.getItem(Token.REFRESH_TOKEN_EXP) || ''
+    )
+  }
+
+  async reissueToken(): Promise<boolean> {
+    const oneMinuteLater = this.getOneMinuteLater()
+    if (
+      !this.accessToken ||
+      !this.refreshToken ||
+      !this.accessTokenExp ||
+      !this.refreshTokenExp ||
+      this.accessTokenExp > oneMinuteLater ||
+      this.refreshTokenExp <= oneMinuteLater
+    )
+      return false
+
+    const data = await reissue(this.refreshToken)
+    if (!data) return false
+
+    TokenManager.setToken(data)
+
+    return true
+  }
+
+  getOneMinuteLater(): Date {
+    const oneMinuteAgo = new Date()
+    oneMinuteAgo.setMinutes(oneMinuteAgo.getMinutes() + 1)
+    return oneMinuteAgo
+  }
+}
+
+export default TokenManager

--- a/packages/app/src/lib/needsTokenRefresh.ts
+++ b/packages/app/src/lib/needsTokenRefresh.ts
@@ -1,0 +1,20 @@
+const needsTokenRefreshData = [
+  { url: '/auth', method: 'POST' },
+  { url: '/student/anonymous/', method: 'GET' },
+  { url: '/major/list', method: 'GET' },
+  { url: '/stack/list', method: 'GET' },
+]
+
+/**
+ * 토큰 재발급 체크를 해야하는 요청인지 검사하는 메소드입니다
+ * true가 나오면 재발급 요청이 필요합니다
+ */
+const needsTokenRefresh = (url?: string, method?: string): boolean => {
+  if (!url || !method) return false
+
+  return !needsTokenRefreshData.filter(
+    (data) => url.includes(data.url) && method.toUpperCase() === data.method
+  )
+}
+
+export default needsTokenRefresh


### PR DESCRIPTION
## 💡 개요

Cookie가 잘 동작하지 않는 관계로 Autorization에 할당하는 방법을 사용하기로 했습니다

## 📃 작업내용

- axios interceptor 추가
- TokenManager 추가
- Obervable 추가
- needsTokenRefresh를 만들어서 인가가 필요한 요청인지 확인

## 🔀 변경사항

- rtk query에서 fetchBaseQuery 대신 CustomBaseQuery를 만들었음