### PR TITLE
[#110] 학생 카드와 학생 디테일 스타일 수정

### DIFF
--- a/packages/app/src/features/student/molecules/StudentDetail/style.ts
+++ b/packages/app/src/features/student/molecules/StudentDetail/style.ts
@@ -103,7 +103,8 @@ export const SchoolInfo = styled.p`
 export const Tags = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.25rem;
+  margin-bottom: 1rem;
 `
 
 export const Tag = styled.span`
@@ -112,7 +113,6 @@ export const Tag = styled.span`
   color: var(--N40);
   padding: 0.35rem 0.75rem;
   border-radius: 0.5rem;
-  margin-bottom: 1rem;
 `
 
 export const Introduce = styled.div`

--- a/packages/app/src/features/student/molecules/StudentDetail/style.ts
+++ b/packages/app/src/features/student/molecules/StudentDetail/style.ts
@@ -19,6 +19,7 @@ export const CloseButton = styled.span`
   top: 1.25rem;
   right: 1.25rem;
   cursor: pointer;
+  z-index: 10;
 `
 
 export const Content = styled.div`

--- a/packages/shared/src/atoms/StudentCard/index.tsx
+++ b/packages/shared/src/atoms/StudentCard/index.tsx
@@ -30,14 +30,15 @@ const StudentCard = ({
         </S.ProfileBackground>
       )}
 
-      <S.Name>{name}</S.Name>
-      <S.Stack>{major}</S.Stack>
+      <div>
+        <S.Name>{name}</S.Name>
+        <S.Stack>{major}</S.Stack>
+      </div>
 
       <S.Tags>
         {techStack?.map((stack) => (
           <S.Tag key={stack}>{stack}</S.Tag>
         ))}
-        <S.Tag>...</S.Tag>
       </S.Tags>
     </S.Wrapper>
   )

--- a/packages/shared/src/atoms/StudentCard/style.ts
+++ b/packages/shared/src/atoms/StudentCard/style.ts
@@ -8,6 +8,19 @@ export const Wrapper = styled.div`
   border-radius: 1.5rem;
   padding: 1.5rem;
   cursor: pointer;
+  overflow: hidden;
+  position: relative;
+
+  ::after {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 1.5rem;
+    left: 0px;
+    bottom: 0px;
+    background: var(--WHITE);
+    pointer-events: none;
+  }
 `
 
 export const ProfileBackground = styled.div`

--- a/packages/shared/src/atoms/StudentCard/style.ts
+++ b/packages/shared/src/atoms/StudentCard/style.ts
@@ -8,19 +8,9 @@ export const Wrapper = styled.div`
   border-radius: 1.5rem;
   padding: 1.5rem;
   cursor: pointer;
-  overflow: hidden;
-  position: relative;
-
-  ::after {
-    content: '';
-    position: absolute;
-    width: 100%;
-    height: 1.5rem;
-    left: 0px;
-    bottom: 0px;
-    background: var(--WHITE);
-    pointer-events: none;
-  }
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 `
 
 export const ProfileBackground = styled.div`
@@ -38,11 +28,11 @@ export const ProfileImg = styled.img`
   aspect-ratio: 1 / 1;
   border-radius: 0.68rem;
   overflow: hidden;
+  object-fit: cover;
 `
 
 export const Name = styled.h2`
   ${({ theme }) => theme.title1}
-  margin-top: 1rem;
 `
 
 export const Stack = styled.p`
@@ -51,10 +41,13 @@ export const Stack = styled.p`
 `
 
 export const Tags = styled.div`
-  margin-top: 1rem;
+  max-height: 4.5rem;
+  height: 100%;
   display: flex;
   flex-wrap: wrap;
+  align-items: flex-start;
   gap: 0.5rem;
+  overflow: hidden;
 `
 
 export const Tag = styled.span`


### PR DESCRIPTION
## 💡 개요

학생 카드와 디테일의 자잘한 스타일 문제를 해결했습니다

## 📃 작업내용

태그가 밖으로 나오는 문제를 그냥 자르는 걸로 해결
<img width="296" alt="image" src="https://github.com/GSM-MSG/SMS-FrontEnd/assets/57276315/d8172704-5d48-40d7-b539-784de82ffb73">

태그들의 간격이 맞지 않는 문제 해결
<img width="468" alt="image" src="https://github.com/GSM-MSG/SMS-FrontEnd/assets/57276315/99f01740-9730-4473-8913-972f626907bb">

닫는 버튼이 아래로 내려가는 문제 해결
<img width="53" alt="image" src="https://github.com/GSM-MSG/SMS-FrontEnd/assets/57276315/188724f1-5d19-4124-bf18-22f51ecde192">