### PR TITLE
[#111] 페이지별 권한 처리

### DIFF
--- a/packages/app/src/api/axiosApi.ts
+++ b/packages/app/src/api/axiosApi.ts
@@ -15,6 +15,8 @@ axiosApi.interceptors.request.use(async (config) => {
 
   if (!isSuccessed) return { ...config, signal: AbortSignal.abort() }
 
+  tokenManager.setTokenFromLocalStorage()
+
   config.headers['Authorization'] =
     tokenManager.accessToken && needsRefresh
       ? `Bearer ${tokenManager.accessToken}`

--- a/packages/app/src/api/rtkApi.ts
+++ b/packages/app/src/api/rtkApi.ts
@@ -3,6 +3,7 @@ import CutomBaseQuery from './CustomBaseQuery'
 
 const rtkApi = createApi({
   baseQuery: CutomBaseQuery,
+  tagTypes: ['Student'],
   endpoints: () => ({}),
 })
 

--- a/packages/app/src/features/auth/hook/useLoggedIn.tsx
+++ b/packages/app/src/features/auth/hook/useLoggedIn.tsx
@@ -19,7 +19,7 @@ const useLoggedIn = () => {
   }, [isSuccess])
 
   return {
-    isExist: data?.isExist,
+    ...data,
     isSuccess,
   }
 }

--- a/packages/app/src/features/auth/hook/useLoggedIn.tsx
+++ b/packages/app/src/features/auth/hook/useLoggedIn.tsx
@@ -1,7 +1,22 @@
 import loggedInApi from '@features/auth/service/loggedInApi'
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
 
 const useLoggedIn = () => {
+  const router = useRouter()
   const { data, isSuccess } = loggedInApi.useLoggedInQuery()
+
+  useEffect(() => {
+    if (isSuccess && !data.isExist) router.push('/register')
+    if (!isSuccess && router.pathname === '/register') router.push('/login')
+    if (isSuccess && router.pathname === '/register' && data.isExist)
+      router.push('/')
+
+    if (isSuccess && router.pathname === '/login' && data.isExist)
+      router.push('/')
+    if (isSuccess && router.pathname === '/login' && !data.isExist)
+      router.push('/register')
+  }, [isSuccess])
 
   return {
     isExist: data?.isExist,

--- a/packages/app/src/features/auth/service/loggedInApi.ts
+++ b/packages/app/src/features/auth/service/loggedInApi.ts
@@ -2,6 +2,7 @@ import { rtkApi } from '@api'
 
 interface Response {
   isExist: boolean
+  role: Role
 }
 
 const loggedInApi = rtkApi.injectEndpoints({

--- a/packages/app/src/features/student/hooks/useStudentDetail.tsx
+++ b/packages/app/src/features/student/hooks/useStudentDetail.tsx
@@ -3,25 +3,31 @@ import { RootState } from '@store'
 import { setStudent } from '@store/studentDetailSlice'
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import useLoggedIn from '@features/auth/hook/useLoggedIn'
 import useModal from './useModal'
 
 const useStudentDetail = () => {
   const [mutation] = studentApi.useStudentDetailMutation()
   const dispatch = useDispatch()
   const { onClose } = useModal()
-  const { id } = useSelector((state: RootState) => ({
+  const { role, isSuccess } = useLoggedIn()
+  const { id: studentId } = useSelector((state: RootState) => ({
     id: state.studentDetail.id,
   }))
 
   useEffect(() => {
-    if (!id) return
+    if (!studentId) return
+    let studentRole = ''
+
+    if (!isSuccess) studentRole = 'anonymous/'
+    else if (role === 'ROLE_TEACHER') studentRole = 'teacher/'
     ;(async () => {
-      const data = await mutation(id)
+      const data = await mutation({ studentId, role: studentRole })
       if ('error' in data) return onClose()
 
       dispatch(setStudent(data.data))
     })()
-  }, [id])
+  }, [studentId])
 }
 
 export default useStudentDetail

--- a/packages/app/src/features/student/hooks/useStudentDetail.tsx
+++ b/packages/app/src/features/student/hooks/useStudentDetail.tsx
@@ -19,7 +19,7 @@ const useStudentDetail = () => {
     if (!studentId) return
     let studentRole = ''
 
-    if (!isSuccess) studentRole = 'anonymous/'
+    if (!isSuccess || !role) studentRole = 'anonymous/'
     else if (role === 'ROLE_TEACHER') studentRole = 'teacher/'
     ;(async () => {
       const data = await mutation({ studentId, role: studentRole })

--- a/packages/app/src/features/student/service/studentApi/index.ts
+++ b/packages/app/src/features/student/service/studentApi/index.ts
@@ -1,6 +1,11 @@
 import { rtkApi } from '@api'
 import Response from './Response'
 
+interface StudentDetailRequest {
+  studentId: string
+  role: string
+}
+
 const studentApi = rtkApi.injectEndpoints({
   endpoints: (build) => ({
     student: build.query<Response, StudentParam>({
@@ -21,9 +26,9 @@ const studentApi = rtkApi.injectEndpoints({
         return JSON.stringify(currentArg) !== JSON.stringify(previousArg)
       },
     }),
-    studentDetail: build.mutation<StudentDetail, string>({
-      query: (studentId) => ({
-        url: `/student/teacher/${studentId}`,
+    studentDetail: build.mutation<StudentDetail, StudentDetailRequest>({
+      query: ({ studentId, role }) => ({
+        url: `/student/${role}${studentId}`,
       }),
     }),
   }),

--- a/packages/app/src/lib/TokenManager.ts
+++ b/packages/app/src/lib/TokenManager.ts
@@ -72,9 +72,6 @@ class TokenManager {
 
     observable.notifyAll(true)
     TokenManager.setToken(data)
-    this.setTokenFromLocalStorage()
-
-    this.setTokenFromLocalStorage()
 
     return true
   }

--- a/packages/app/src/pages/login.tsx
+++ b/packages/app/src/pages/login.tsx
@@ -1,7 +1,10 @@
 import { SEO } from '@components'
+import useLoggedIn from '@features/auth/hook/useLoggedIn'
 import LoginTemplate from '@templates/LoginTemplate'
 
 const Login = () => {
+  useLoggedIn()
+
   return (
     <>
       <SEO title='login' />

--- a/packages/app/src/pages/register.tsx
+++ b/packages/app/src/pages/register.tsx
@@ -1,7 +1,9 @@
+import useLoggedIn from '@features/auth/hook/useLoggedIn'
 import { RegisterForm } from '@features/register/organisms'
 import RegisterLayout from '@layouts/RegisterLayout'
 
 const Register = () => {
+  useLoggedIn()
   return (
     <RegisterLayout>
       <RegisterForm />

--- a/packages/app/src/types/Role.d.ts
+++ b/packages/app/src/types/Role.d.ts
@@ -1,0 +1,1 @@
+type Role = 'ROLE_STUDENT' | 'ROLE_TEACHER'


### PR DESCRIPTION
## 💡 개요

페이지별 권한 처리를 추가했습니다

## 📃 작업내용

- 각각의 페이지에 권한에 따라 접근 할 수 있는지 없는지를 처리했습니다
- 권한에 따라 학생 디테일 요청을 날릴 수 있게 변경했습니다

## 🎸 기타

모든 권한 처리를 useLoggedIn이라는 훅에서 처리해서 나중에 쉽게 처리하는 방법을 찾아봐야 할 것 같습니다