### PR TITLE
[#121] 메인 페이지 반응형 및 디자인 수정

### DIFF
--- a/packages/app/src/features/student/molecules/StudentDetail/style.ts
+++ b/packages/app/src/features/student/molecules/StudentDetail/style.ts
@@ -63,6 +63,10 @@ export const TemeporaryImage = styled.div`
   border-bottom-right-radius: 1.5rem;
   border-bottom-left-radius: 1.5rem;
   overflow: hidden;
+
+  @media (max-width: 34rem) {
+    width: 100%;
+  }
 `
 
 export const RightContent = styled.div`

--- a/packages/app/src/features/student/molecules/StudentList/style.ts
+++ b/packages/app/src/features/student/molecules/StudentList/style.ts
@@ -9,6 +9,7 @@ export const Content = styled.div`
 
   @media (max-width: 41.5rem) {
     width: 100%;
+    gap: 0;
   }
 `
 
@@ -19,6 +20,10 @@ export const MaxCount = styled.p`
   display: flex;
   align-items: center;
   gap: 0.25rem;
+
+  @media (max-width: 41.5rem) {
+    padding: 0 1.25rem;
+  }
 `
 
 export const Count = styled.span`
@@ -47,5 +52,6 @@ export const Students = styled.div`
   @media (max-width: 41.5rem) {
     width: 100%;
     grid-template-columns: repeat(1, 1fr);
+    gap: 0;
   }
 `

--- a/packages/app/src/features/student/templates/StudentsTemplate/style.ts
+++ b/packages/app/src/features/student/templates/StudentsTemplate/style.ts
@@ -9,7 +9,9 @@ export const Wrapper = styled.main`
   gap: 3rem;
   background: var(--N10);
 
-  @media (max-width: 30rem) {
+  @media (max-width: 41.5rem) {
     padding-top: 0;
+    background: var(--WHITE);
+    gap: 2rem;
   }
 `

--- a/packages/shared/src/atoms/StudentCard/style.ts
+++ b/packages/shared/src/atoms/StudentCard/style.ts
@@ -34,7 +34,10 @@ export const ProfileBackground = styled.div`
   border-radius: 0.68rem;
 
   @media (max-width: 41.5rem) {
-    overflow: scroll;
+    min-width: 6.25rem;
+    min-height: 6.25rem;
+    width: 6.25rem;
+    height: 6.25rem;
   }
 `
 

--- a/packages/shared/src/atoms/StudentCard/style.ts
+++ b/packages/shared/src/atoms/StudentCard/style.ts
@@ -21,6 +21,7 @@ export const Wrapper = styled.div`
     align-items: flex-start;
     gap: 0.75rem;
     border-radius: 0;
+    padding: 1rem 1.25rem;
   }
 `
 

--- a/packages/shared/src/atoms/StudentCard/style.ts
+++ b/packages/shared/src/atoms/StudentCard/style.ts
@@ -12,6 +12,10 @@ export const Wrapper = styled.div`
   flex-direction: column;
   gap: 1rem;
 
+  &:nth-of-type(n + 2) {
+    border-top: 1px solid var(--N10);
+  }
+
   @media (max-width: 41.5rem) {
     width: 100vw;
     height: auto;

--- a/packages/shared/src/molecules/Header/style.ts
+++ b/packages/shared/src/molecules/Header/style.ts
@@ -28,6 +28,7 @@ export const Wrapper = styled.div`
 
 export const LogoWrapper = styled(Link)`
   margin-left: 1rem;
+  width: 5rem;
   height: 2rem;
   cursor: pointer;
 
@@ -41,6 +42,10 @@ export const InfoWrapper = styled.div`
   display: flex;
   gap: 1rem;
   position: relative;
+
+  @media (max-width: 41.5rem) {
+    gap: 1.25rem;
+  }
 `
 
 export const Filter = styled.div`
@@ -53,7 +58,7 @@ export const Filter = styled.div`
   gap: 0.25rem;
   cursor: pointer;
 
-  @media (max-width: 30rem) {
+  @media (max-width: 41.5rem) {
     background: transparent;
     padding: 0;
 
@@ -70,6 +75,11 @@ export const UserCircle = styled.div`
   overflow: hidden;
   background: var(--N10);
   cursor: pointer;
+
+  @media (max-width: 41.5rem) {
+    width: 2rem;
+    height: 2rem;
+  }
 `
 
 export const UserCircleLink = styled(Link)`

--- a/packages/shared/src/molecules/Header/style.ts
+++ b/packages/shared/src/molecules/Header/style.ts
@@ -16,7 +16,7 @@ export const Wrapper = styled.div`
   position: sticky;
   top: 2.5rem;
 
-  @media (max-width: 30rem) {
+  @media (max-width: 41.5rem) {
     max-width: 100%;
     width: 100%;
     top: 0;


### PR DESCRIPTION
## 💡 개요

모바일에서 봤을 때 깨지던 디자인을 수정했습니다

<img width="375" alt="image" src="https://github.com/GSM-MSG/SMS-FrontEnd/assets/57276315/dec5fed0-1325-46c0-844e-f62b04a069e4">

![image](https://github.com/GSM-MSG/SMS-FrontEnd/assets/57276315/6fb5ba1e-7ceb-4f64-9288-49e50ba1bdca)


## 📃 작업내용

- 학생 카드 반응형 수정
- 해더 반응형 수정
- 학생 임시 이미지 사이즈 수정
- 학생 카드 사이사이 border 추가