### PR TITLE
[#115] 회원 가입시 입력 값 제한 추가

### DIFF
--- a/packages/app/src/features/register/molecules/ProfileInputs/index.tsx
+++ b/packages/app/src/features/register/molecules/ProfileInputs/index.tsx
@@ -94,6 +94,7 @@ const ProfileInputs = ({
           onChange={onChange}
           dropdownList={dropdownList}
           setValue={setValue}
+          limit={5}
         />
       </InputColumn>
     </FormWrapper>

--- a/packages/app/src/features/register/molecules/ProfileInputs/index.tsx
+++ b/packages/app/src/features/register/molecules/ProfileInputs/index.tsx
@@ -38,6 +38,7 @@ const ProfileInputs = ({
         <Profile
           {...register('profileImgUrl', {
             required: { value: true, message: '필수 값입니다' },
+            maxLength: { value: 50, message: '최대 50자 까지 가능합니다' },
           })}
           error={errors.profileImgUrl?.message}
           onUpload={onUpload}

--- a/packages/app/src/features/register/molecules/ProfileInputs/index.tsx
+++ b/packages/app/src/features/register/molecules/ProfileInputs/index.tsx
@@ -38,7 +38,6 @@ const ProfileInputs = ({
         <Profile
           {...register('profileImgUrl', {
             required: { value: true, message: '필수 값입니다' },
-            maxLength: { value: 50, message: '최대 50자 까지 가능합니다' },
           })}
           error={errors.profileImgUrl?.message}
           onUpload={onUpload}
@@ -48,6 +47,7 @@ const ProfileInputs = ({
         <Input
           {...register('introduce', {
             required: { value: true, message: '필수 값입니다' },
+            maxLength: { value: 50, message: '최대 50자 까지 가능합니다' },
           })}
           error={errors.introduce?.message}
           onReset={() => resetField('introduce')}

--- a/packages/app/src/features/register/molecules/SchoolInputs/index.tsx
+++ b/packages/app/src/features/register/molecules/SchoolInputs/index.tsx
@@ -22,6 +22,7 @@ const SchoolInputs = ({ register, onUpload, errors, resetField }: Props) => {
         <Input
           {...register('gsmAuthenticationScore', {
             required: { value: true, message: '필수 값입니다' },
+            max: { value: 990, message: '최대 990점 까지 가능합니다' },
             valueAsNumber: true,
           })}
           placeholder='인증 점수 입력'

--- a/packages/shared/src/molecules/SearchInput/index.tsx
+++ b/packages/shared/src/molecules/SearchInput/index.tsx
@@ -9,9 +9,16 @@ interface Props {
   dropdownList: string[]
   setValue: UseFormSetValue<any>
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void
+  limit?: number
 }
 
-const SearchInput = ({ dropdownList, name, setValue, onChange }: Props) => {
+const SearchInput = ({
+  dropdownList,
+  name,
+  setValue,
+  onChange,
+  limit,
+}: Props) => {
   const [searchValue, setSearchValue] = useState<string>('')
   const [stacks, setStacks] = useState<string>('')
   const [isShow, setIsShow] = useState<boolean>(false)
@@ -56,6 +63,7 @@ const SearchInput = ({ dropdownList, name, setValue, onChange }: Props) => {
           onChange={changeHandler}
           value={searchValue}
           onReset={() => setSearchValue('')}
+          disabled={limit ? stacks.split(',').length >= limit : false}
         />
         <Dropdown.Menu isShow={isShow && !!searchValue} onClose={onClose}>
           {dropdownList?.map((i, idx) => (


### PR DESCRIPTION
## 💡 개요

회원 가입을 할 때 input에 입력 값을 제한하는 코드를 추가했습니다

## 📃 작업내용

- 자기소개 50자 제한 추가
- gsm 인증제 990까지 제한 추가
- 세부 스택 5개 까지 제한 추가