### PR TITLE
[#125] 토큰 만료 처리

### DIFF
--- a/packages/app/src/api/axiosApi.ts
+++ b/packages/app/src/api/axiosApi.ts
@@ -1,11 +1,12 @@
 import axios, { isAxiosError } from 'axios'
 import env from '@lib/env'
-import tokenManager from '@lib/TokenManager'
+import TokenManager from '@lib/TokenManager'
 import needsTokenRefresh from '@lib/needsTokenRefresh'
 
 const axiosApi = axios.create({ baseURL: env.NEXT_PUBLIC_SERVER_URL })
 
 axiosApi.interceptors.request.use(async (config) => {
+  const tokenManager = new TokenManager()
   let isSuccessed = true
   const needsRefresh = needsTokenRefresh(config.url, config.method)
 
@@ -35,7 +36,7 @@ axiosApi.interceptors.response.use(
     )
       return Promise.reject(config)
 
-    tokenManager.clearToken()
+    TokenManager.clearToken()
 
     return axiosApi({
       url: config.config?.url,

--- a/packages/app/src/lib/TokenManager.ts
+++ b/packages/app/src/lib/TokenManager.ts
@@ -13,26 +13,18 @@ class TokenManager {
     this.setTokenFromLocalStorage()
   }
 
-  setToken(tokens: ReissueResponse) {
+  static setToken(tokens: ReissueResponse) {
     localStorage.setItem(Token.ACCESS_TOKEN, tokens.accessToken)
     localStorage.setItem(Token.REFRESH_TOKEN, tokens.refreshToken)
     localStorage.setItem(Token.ACCESS_TOKEN_EXP, tokens.accessTokenExp)
     localStorage.setItem(Token.REFRESH_TOKEN_EXP, tokens.refreshTokenExp)
-    this.accessTokenExp = new Date(tokens.accessTokenExp)
-    this.refreshTokenExp = new Date(tokens.refreshTokenExp)
-    this.accessToken = tokens.accessToken
-    this.refreshToken = tokens.refreshToken
   }
 
-  clearToken() {
+  static clearToken() {
     localStorage.removeItem(Token.ACCESS_TOKEN)
     localStorage.removeItem(Token.REFRESH_TOKEN)
     localStorage.removeItem(Token.ACCESS_TOKEN_EXP)
     localStorage.removeItem(Token.REFRESH_TOKEN_EXP)
-    this.accessTokenExp = null
-    this.refreshTokenExp = null
-    this.accessToken = null
-    this.refreshToken = null
   }
 
   setTokenFromLocalStorage() {
@@ -64,7 +56,7 @@ class TokenManager {
       this.accessTokenExp <= oneMinuteLater &&
       this.refreshTokenExp <= oneMinuteLater
     ) {
-      this.clearToken()
+      TokenManager.clearToken()
       return true
     }
 
@@ -89,7 +81,7 @@ class TokenManager {
     }
 
     observable.notifyAll(true)
-    this.setToken(data)
+    TokenManager.setToken(data)
 
     return true
   }
@@ -101,6 +93,4 @@ class TokenManager {
   }
 }
 
-const tokenManager = new TokenManager()
-
-export default tokenManager
+export default TokenManager


### PR DESCRIPTION
## 💡 개요

메인페이지에서 토큰을 변조 하면 401이 나오고 students 값은 아무것도 없는 상태로 나오는 문제가 발생했습니다
토큰 만료 처리를 추가했습니다

## 📃 작업내용

- response interceptor에서 토큰이 변조되었을 경우 처리를 진행했습니다
- 또한 토큰이 만료되었을 경우 가지고 있는 토큰을 전부 지우는 로직을 추가했습니다
- student값이 나오지 않는 문제를 해결하기 위해 interceptor에 retry를 하는 코드를 추가했습니다