### PR TITLE
[#127] api 요청에 toast 띄우기

### DIFF
--- a/packages/app/src/features/auth/errors.ts
+++ b/packages/app/src/features/auth/errors.ts
@@ -1,5 +1,23 @@
+import env from '@lib/env'
 import Errors from '@/types/Errors'
 
-const errors: Errors = {}
+const errors: Errors = {
+  [env.NEXT_PUBLIC_SERVER_URL]: {
+    '/auth': {
+      POST: {
+        400: '시크릿 값이 일치하지 않습니다',
+        401: '코드 값이 만료되었습니다',
+        404: '서비스를 찾을 수 없습니다',
+        500: 'Gauth에 문제가 발생했습니다',
+      },
+      DELETE: {
+        404: '토큰 값이 올바르지 않습니다',
+      },
+    },
+    '/auth/withdrawal': {
+      DELETE: {},
+    },
+  },
+}
 
 export default errors

--- a/packages/app/src/features/auth/hook/useAuth.tsx
+++ b/packages/app/src/features/auth/hook/useAuth.tsx
@@ -2,18 +2,21 @@ import { useRouter } from 'next/router'
 import env from '@lib/env'
 import { useEffect } from 'react'
 import login from '@features/auth/service/login'
+import { useToast } from '@features/toast'
 
 const useAuth = () => {
   const router = useRouter()
   const code = router.query.code?.toString() || ''
+  const { addToast } = useToast()
 
   useEffect(() => {
     if (!code) return
     ;(async () => {
       const res = await login(code)
 
-      if (!res) return
+      if (typeof res === 'string') return addToast('error', res)
 
+      addToast('success', '로그인에 성공했습니다')
       router.push(res.isExist ? '/' : '/register')
     })()
   }, [code])

--- a/packages/app/src/features/auth/hook/useLogout.tsx
+++ b/packages/app/src/features/auth/hook/useLogout.tsx
@@ -1,13 +1,13 @@
-import { useRouter } from 'next/router'
 import logout from '@features/auth/service/logout'
 import TokenManager from '@lib/TokenManager'
 import { useDialog } from '@hooks'
 import { useToast } from '@features/toast'
+import { studentApi } from '@features/student'
 
 const useLogout = () => {
   const { dialog } = useDialog()
-  const router = useRouter()
   const { addToast } = useToast()
+  const [mutation] = studentApi.useRefetchStudentMutation()
 
   const onLogout = async () => {
     if (
@@ -24,7 +24,7 @@ const useLogout = () => {
     TokenManager.clearToken()
 
     addToast('success', '로그아웃에 성공했습니다')
-    router.reload()
+    mutation()
   }
 
   return { onLogout }

--- a/packages/app/src/features/auth/hook/useLogout.tsx
+++ b/packages/app/src/features/auth/hook/useLogout.tsx
@@ -2,10 +2,12 @@ import { useRouter } from 'next/router'
 import logout from '@features/auth/service/logout'
 import TokenManager from '@lib/TokenManager'
 import { useDialog } from '@hooks'
+import { useToast } from '@features/toast'
 
 const useLogout = () => {
   const { dialog } = useDialog()
   const router = useRouter()
+  const { addToast } = useToast()
 
   const onLogout = async () => {
     if (
@@ -15,9 +17,13 @@ const useLogout = () => {
       }))
     )
       return
-    if (!(await logout())) return
+
+    const res = await logout()
+    if (res) return addToast('error', res)
 
     TokenManager.clearToken()
+
+    addToast('success', '로그아웃에 성공했습니다')
     router.reload()
   }
 

--- a/packages/app/src/features/auth/hook/useWithdraw.tsx
+++ b/packages/app/src/features/auth/hook/useWithdraw.tsx
@@ -1,4 +1,5 @@
 import withdraw from '@features/auth/service/withdraw'
+import { useToast } from '@features/toast'
 import { useDialog } from '@hooks'
 import TokenManager from '@lib/TokenManager'
 import { useRouter } from 'next/router'
@@ -6,6 +7,7 @@ import { useRouter } from 'next/router'
 const useWithdraw = () => {
   const { dialog } = useDialog()
   const router = useRouter()
+  const { addToast } = useToast()
 
   const onWithdraw = async () => {
     if (
@@ -15,9 +17,12 @@ const useWithdraw = () => {
       }))
     )
       return
-    if (!(await withdraw())) return
+
+    const res = await withdraw()
+    if (res) return addToast('error', res)
 
     TokenManager.clearToken()
+    addToast('success', '회원탈퇴에 성공했습니다')
     router.reload()
   }
 

--- a/packages/app/src/features/auth/hook/useWithdraw.tsx
+++ b/packages/app/src/features/auth/hook/useWithdraw.tsx
@@ -1,13 +1,13 @@
 import withdraw from '@features/auth/service/withdraw'
+import { studentApi } from '@features/student'
 import { useToast } from '@features/toast'
 import { useDialog } from '@hooks'
 import TokenManager from '@lib/TokenManager'
-import { useRouter } from 'next/router'
 
 const useWithdraw = () => {
   const { dialog } = useDialog()
-  const router = useRouter()
   const { addToast } = useToast()
+  const [mutation] = studentApi.useRefetchStudentMutation()
 
   const onWithdraw = async () => {
     if (
@@ -23,7 +23,7 @@ const useWithdraw = () => {
 
     TokenManager.clearToken()
     addToast('success', '회원탈퇴에 성공했습니다')
-    router.reload()
+    mutation()
   }
 
   return { onWithdraw }

--- a/packages/app/src/features/auth/service/login.ts
+++ b/packages/app/src/features/auth/service/login.ts
@@ -1,7 +1,7 @@
 import { axiosApi } from '@api'
+import { TokenResponse } from '@features/auth/type/TokenResponse'
 import ErrorMapper from '@lib/ErrorMapper'
 import errors from '@features/auth/errors'
-import { TokenResponse } from '@features/auth/type/TokenResponse'
 import TokenManager from '@lib/TokenManager'
 
 const login = async (code: string) => {
@@ -11,8 +11,7 @@ const login = async (code: string) => {
 
     return data
   } catch (e) {
-    alert(ErrorMapper(e, errors))
-    return
+    return ErrorMapper(e, errors)
   }
 }
 

--- a/packages/app/src/features/auth/service/logout.ts
+++ b/packages/app/src/features/auth/service/logout.ts
@@ -1,5 +1,7 @@
 import { axiosApi } from '@api'
+import ErrorMapper from '@lib/ErrorMapper'
 import TokenManager from '@lib/TokenManager'
+import errors from '@features/auth/errors'
 
 const logout = async () => {
   try {
@@ -10,9 +12,9 @@ const logout = async () => {
       },
     })
 
-    return true
+    return
   } catch (e) {
-    return false
+    return ErrorMapper(e, errors)
   }
 }
 

--- a/packages/app/src/features/auth/service/withdraw.ts
+++ b/packages/app/src/features/auth/service/withdraw.ts
@@ -1,12 +1,14 @@
 import { axiosApi } from '@api'
+import ErrorMapper from '@lib/ErrorMapper'
+import errors from '@features/auth/errors'
 
 const withdraw = async () => {
   try {
     await axiosApi.delete('/auth/withdrawal')
 
-    return true
+    return
   } catch (e) {
-    return false
+    return ErrorMapper(e, errors)
   }
 }
 

--- a/packages/app/src/features/register/hooks/useRegister.tsx
+++ b/packages/app/src/features/register/hooks/useRegister.tsx
@@ -65,7 +65,7 @@ const useRegister = () => {
     const res = await PostStudentInfoService(form)
     if (res) return addToast('error', ErrorMapper(res, apiErrors))
 
-    addToast('error', '학생 정보 기입에 성공했습니다')
+    addToast('success', '학생 정보 기입에 성공했습니다')
     router.push('/')
   })
 

--- a/packages/app/src/features/register/hooks/useRegister.tsx
+++ b/packages/app/src/features/register/hooks/useRegister.tsx
@@ -1,5 +1,8 @@
 import { RegisterFormType } from '@features/register/type'
 import { ChangeEvent } from 'react'
+import { useToast } from '@features/toast'
+import apiErrors from '@features/register/services/errors'
+import ErrorMapper from '@lib/ErrorMapper'
 import { useForm } from 'react-hook-form'
 import {
   PostStudentInfoService,
@@ -8,6 +11,7 @@ import {
 import { useRouter } from 'next/router'
 
 const useRegister = () => {
+  const { addToast } = useToast()
   const router = useRouter()
   const {
     register,
@@ -23,15 +27,18 @@ const useRegister = () => {
     // TODO 리팩토링
     if (!e.target.files || !e.target.files[0]) {
       setError('profileImgUrl', { message: '이미지 업로드에 실패했습니다' })
+      addToast('error', '이미지 업로드에 실패했습니다')
       return ''
     }
     const imageUrl = await PostFileService(e.target.files[0], true)
     if (!imageUrl) {
       setError('profileImgUrl', { message: '이미지 업로드에 실패했습니다' })
+      addToast('error', '이미지 업로드에 실패했습니다')
       return ''
     }
     setValue('profileImgUrl', imageUrl)
 
+    addToast('success', '이미지 업로드에 성공했습니다')
     return imageUrl
   }
 
@@ -39,21 +46,26 @@ const useRegister = () => {
     // TODO 리팩토링
     if (!e.target.files || !e.target.files[0]) {
       setError('dreamBookFileUrl', { message: '업로드에 실패했습니다' })
+      addToast('error', '업로드에 실패했습니다')
       return ''
     }
     const fileUrl = await PostFileService(e.target.files[0], false)
     if (!fileUrl) {
       setError('dreamBookFileUrl', { message: '업로드에 실패했습니다' })
+      addToast('error', '업로드에 실패했습니다')
       return ''
     }
     setValue('dreamBookFileUrl', fileUrl)
 
+    addToast('success', '업로드에 성공했습니다')
     return fileUrl
   }
 
   const onSubmit = handleSubmit(async (form: RegisterFormType) => {
-    if (!(await PostStudentInfoService(form))) return
+    const res = await PostStudentInfoService(form)
+    if (res) return addToast('error', ErrorMapper(res, apiErrors))
 
+    addToast('error', '학생 정보 기입에 성공했습니다')
     router.push('/')
   })
 

--- a/packages/app/src/features/register/services/PostFileService/index.tsx
+++ b/packages/app/src/features/register/services/PostFileService/index.tsx
@@ -1,12 +1,7 @@
 import { axiosApi } from '@api'
-import ErrorMapper from '@lib/ErrorMapper'
-import errors from '@features/register/services/errors'
 import { Response } from './response'
 
-const PostFileService = async (
-  file: File,
-  isImage: boolean
-): Promise<string | undefined> => {
+const PostFileService = async (file: File, isImage: boolean) => {
   const formData = new FormData()
   formData.append('file', file)
 
@@ -21,7 +16,6 @@ const PostFileService = async (
 
     return data.fileUrl
   } catch (e) {
-    alert(ErrorMapper(e, errors))
     return
   }
 }

--- a/packages/app/src/features/register/services/PostStudentInfoService/index.tsx
+++ b/packages/app/src/features/register/services/PostStudentInfoService/index.tsx
@@ -1,11 +1,7 @@
 import { axiosApi } from '@api'
 import { RegisterFormType } from '@features/register/type'
-import ErrorMapper from '@lib/ErrorMapper'
-import errors from '@features/register/services/errors'
 
-const PostStudentInfoService = async (
-  form: RegisterFormType
-): Promise<boolean> => {
+const PostStudentInfoService = async (form: RegisterFormType) => {
   try {
     await axiosApi.post('/student', {
       ...form,
@@ -15,10 +11,9 @@ const PostStudentInfoService = async (
         .filter((i) => !!i),
     })
 
-    return true
+    return
   } catch (e) {
-    alert(ErrorMapper(e, errors))
-    return false
+    return e
   }
 }
 

--- a/packages/app/src/features/student/hooks/useStudent.tsx
+++ b/packages/app/src/features/student/hooks/useStudent.tsx
@@ -9,7 +9,11 @@ const useStudent = () => {
   const { studentParam } = useSelector((state: RootState) => ({
     studentParam: state.studentParam,
   }))
-  const { data, isLoading } = studentApi.useStudentQuery(studentParam.param)
+  const { data, isLoading } = studentApi.useStudentQuery(studentParam.param, {
+    refetchOnMountOrArgChange: true,
+    refetchOnReconnect: true,
+    refetchOnFocus: true,
+  })
 
   useEffect(() => {
     if (isLoading) return

--- a/packages/app/src/features/student/service/studentApi/index.ts
+++ b/packages/app/src/features/student/service/studentApi/index.ts
@@ -13,7 +13,9 @@ const studentApi = rtkApi.injectEndpoints({
         url: `/student`,
         params,
       }),
-      merge: (current, newData) => {
+      providesTags: [{ type: 'Student' }],
+      merge: (current, newData, { arg }) => {
+        if (arg.page === 1) return newData
         return {
           ...newData,
           content: [...current.content, ...newData.content],
@@ -26,6 +28,18 @@ const studentApi = rtkApi.injectEndpoints({
         return JSON.stringify(currentArg) !== JSON.stringify(previousArg)
       },
     }),
+
+    refetchStudent: build.mutation<Response, void>({
+      query: () => ({
+        url: '/student',
+        params: {
+          page: 1,
+          size: 20,
+        },
+      }),
+      invalidatesTags: [{ type: 'Student' }],
+    }),
+
     studentDetail: build.mutation<StudentDetail, StudentDetailRequest>({
       query: ({ studentId, role }) => ({
         url: `/student/${role}${studentId}`,


### PR DESCRIPTION
## 💡 개요

api 요청에 toast를 띄우는 작업을 진행했습니다

## 📃 작업내용

- 로그인, 로그아웃, 회원탈퇴, 회원가입, 이미지 업로드 api 요청에 toast를 띄우게 만들었습니다

## 🔀 변경사항

로그인과 로그아웃이 끝난 후에 페이지를 reload 하는 게 아니라 student 값을 다시 가져오는 방식으로 변경했습니다

## 🎸 기타

백 명세서에 에러 관련된 명세가 잘 되어 있지 않아 나중에 추가해야할 것 같습니다