### PR TITLE
[#131] 무한 요청 문제 해결

### DIFF
--- a/packages/app/src/api/axiosApi.ts
+++ b/packages/app/src/api/axiosApi.ts
@@ -27,24 +27,11 @@ axiosApi.interceptors.response.use(
     return config
   },
   async (config) => {
-    if (!isAxiosError(config)) return config
+    if (!isAxiosError(config)) return Promise.reject(config)
 
-    if (
-      (config.response?.config.url === '/auth/verify/access' &&
-        config.response.config.method?.toUpperCase() === 'GET') ||
-      config.response?.status !== 401
-    )
-      return Promise.reject(config)
+    if (config.response?.status === 401) TokenManager.clearToken()
 
-    TokenManager.clearToken()
-
-    return axiosApi({
-      url: config.config?.url,
-      method: config.config?.method,
-      headers: config.config?.headers,
-      params: config.config?.params,
-      data: config.config?.data,
-    })
+    return Promise.reject(config)
   }
 )
 

--- a/packages/app/src/features/student/hooks/useStudent.tsx
+++ b/packages/app/src/features/student/hooks/useStudent.tsx
@@ -1,4 +1,7 @@
 import { studentApi } from '@features/student'
+import errors from '@features/student/service/errors'
+import { useToast } from '@features/toast'
+import ErrorMapper from '@lib/ErrorMapper'
 import { RootState } from '@store'
 import { nextStop, setLoading } from '@store/studentParamSlice'
 import { useEffect } from 'react'
@@ -6,14 +9,25 @@ import { useDispatch, useSelector } from 'react-redux'
 
 const useStudent = () => {
   const dispatch = useDispatch()
+  const { addToast } = useToast()
   const { studentParam } = useSelector((state: RootState) => ({
     studentParam: state.studentParam,
   }))
-  const { data, isLoading } = studentApi.useStudentQuery(studentParam.param, {
-    refetchOnMountOrArgChange: true,
-    refetchOnReconnect: true,
-    refetchOnFocus: true,
-  })
+  const { data, isLoading, isError, error } = studentApi.useStudentQuery(
+    studentParam.param,
+    {
+      refetchOnMountOrArgChange: true,
+      refetchOnReconnect: true,
+      refetchOnFocus: true,
+    }
+  )
+
+  useEffect(() => {
+    if (!isError) return
+
+    if (typeof error === 'string') return addToast('error', error)
+    addToast('error', ErrorMapper(error, errors))
+  }, [isError])
 
   useEffect(() => {
     if (isLoading) return

--- a/packages/app/src/features/student/service/errors.ts
+++ b/packages/app/src/features/student/service/errors.ts
@@ -1,0 +1,14 @@
+import env from '@lib/env'
+import Errors from '@/types/Errors'
+
+const errors: Errors = {
+  [env.NEXT_PUBLIC_SERVER_URL]: {
+    '/student': {
+      GET: {
+        401: '페이지를 다시 로드해주세요',
+      },
+    },
+  },
+}
+
+export default errors


### PR DESCRIPTION
## 💡 개요

가끔 요청을 하다 잘못 걸리면 무한 요청에 빠지는 경우가 생겼습니다
본의아니게 ddos공격을 하게돼서 수정을 하게 되었습니다

## 📃 작업내용

- axios의 response interceptor에 retry 기능을 제거하고 401에러가 발생하면 토큰을 지우도록 변경했습니다
- 학생 리스트를 요청할 때 실패를 하면 에러 toast를 띄우는 기능 추가