### PR TITLE
[#130] 페이지 별 권한 로직 수정

### DIFF
--- a/packages/app/src/api/rtkApi.ts
+++ b/packages/app/src/api/rtkApi.ts
@@ -3,7 +3,7 @@ import CutomBaseQuery from './CustomBaseQuery'
 
 const rtkApi = createApi({
   baseQuery: CutomBaseQuery,
-  tagTypes: ['Student'],
+  tagTypes: ['Student', 'My'],
   endpoints: () => ({}),
 })
 

--- a/packages/app/src/features/auth/hook/useLoggedIn.tsx
+++ b/packages/app/src/features/auth/hook/useLoggedIn.tsx
@@ -10,6 +10,7 @@ interface Props {
 const useLoggedIn = ({ redirectTo, redirectToIfFound }: Props) => {
   const router = useRouter()
   const { data, isLoading, isSuccess } = loggedInApi.useLoggedInQuery()
+  const [refetchLoggedIn] = loggedInApi.useRefetchLoggedInMutation()
 
   useEffect(() => {
     if ((!redirectTo && isLoading) || (!redirectToIfFound && isLoading)) return
@@ -30,6 +31,7 @@ const useLoggedIn = ({ redirectTo, redirectToIfFound }: Props) => {
 
   return {
     ...data,
+    refetchLoggedIn,
     isSuccess,
   }
 }

--- a/packages/app/src/features/auth/hook/useLoggedIn.tsx
+++ b/packages/app/src/features/auth/hook/useLoggedIn.tsx
@@ -2,21 +2,31 @@ import loggedInApi from '@features/auth/service/loggedInApi'
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
 
-const useLoggedIn = () => {
+interface Props {
+  redirectTo?: string
+  redirectToIfFound?: string
+}
+
+const useLoggedIn = ({ redirectTo, redirectToIfFound }: Props) => {
   const router = useRouter()
-  const { data, isSuccess } = loggedInApi.useLoggedInQuery()
+  const { data, isLoading, isSuccess } = loggedInApi.useLoggedInQuery()
 
   useEffect(() => {
-    if (isSuccess && !data.isExist) router.push('/register')
-    if (!isSuccess && router.pathname === '/register') router.push('/login')
-    if (isSuccess && router.pathname === '/register' && data.isExist)
-      router.push('/')
+    if ((!redirectTo && isLoading) || (!redirectToIfFound && isLoading)) return
 
-    if (isSuccess && router.pathname === '/login' && data.isExist)
-      router.push('/')
-    if (isSuccess && router.pathname === '/login' && !data.isExist)
-      router.push('/register')
-  }, [isSuccess])
+    if (isSuccess && router.pathname === '/register' && !data.isExist) return
+    if (isSuccess && !data.isExist) router.push('/register')
+
+    if (isSuccess && redirectToIfFound) {
+      router.push(redirectToIfFound)
+      return
+    }
+
+    if (!isSuccess && redirectTo) {
+      router.push(redirectTo)
+      return
+    }
+  }, [data, isLoading, redirectTo, isSuccess, redirectToIfFound])
 
   return {
     ...data,

--- a/packages/app/src/features/auth/hook/useLogout.tsx
+++ b/packages/app/src/features/auth/hook/useLogout.tsx
@@ -3,11 +3,13 @@ import TokenManager from '@lib/TokenManager'
 import { useDialog } from '@hooks'
 import { useToast } from '@features/toast'
 import { studentApi } from '@features/student'
+import useLoggedIn from './useLoggedIn'
 
 const useLogout = () => {
   const { dialog } = useDialog()
   const { addToast } = useToast()
   const [mutation] = studentApi.useRefetchStudentMutation()
+  const { refetchLoggedIn } = useLoggedIn({})
 
   const onLogout = async () => {
     if (
@@ -25,6 +27,7 @@ const useLogout = () => {
 
     addToast('success', '로그아웃에 성공했습니다')
     mutation()
+    refetchLoggedIn()
   }
 
   return { onLogout }

--- a/packages/app/src/features/auth/hook/useWithdraw.tsx
+++ b/packages/app/src/features/auth/hook/useWithdraw.tsx
@@ -3,11 +3,13 @@ import { studentApi } from '@features/student'
 import { useToast } from '@features/toast'
 import { useDialog } from '@hooks'
 import TokenManager from '@lib/TokenManager'
+import useLoggedIn from './useLoggedIn'
 
 const useWithdraw = () => {
   const { dialog } = useDialog()
   const { addToast } = useToast()
   const [mutation] = studentApi.useRefetchStudentMutation()
+  const { refetchLoggedIn } = useLoggedIn({})
 
   const onWithdraw = async () => {
     if (
@@ -24,6 +26,7 @@ const useWithdraw = () => {
     TokenManager.clearToken()
     addToast('success', '회원탈퇴에 성공했습니다')
     mutation()
+    refetchLoggedIn()
   }
 
   return { onWithdraw }

--- a/packages/app/src/features/auth/service/loggedInApi.ts
+++ b/packages/app/src/features/auth/service/loggedInApi.ts
@@ -9,6 +9,11 @@ const loggedInApi = rtkApi.injectEndpoints({
   endpoints: (build) => ({
     loggedIn: build.query<Response, void>({
       query: () => ({ url: '/auth/verify/access' }),
+      providesTags: [{ type: 'My' }],
+    }),
+    refetchLoggedIn: build.mutation<Response, void>({
+      query: () => ({ url: '/auth/verify/access' }),
+      invalidatesTags: [{ type: 'My' }],
     }),
   }),
 })

--- a/packages/app/src/features/student/hooks/useStudentDetail.tsx
+++ b/packages/app/src/features/student/hooks/useStudentDetail.tsx
@@ -10,7 +10,7 @@ const useStudentDetail = () => {
   const [mutation] = studentApi.useStudentDetailMutation()
   const dispatch = useDispatch()
   const { onClose } = useModal()
-  const { role, isSuccess } = useLoggedIn()
+  const { role, isSuccess } = useLoggedIn({})
   const { id: studentId } = useSelector((state: RootState) => ({
     id: state.studentDetail.id,
   }))

--- a/packages/app/src/features/student/templates/StudentsTemplate/index.tsx
+++ b/packages/app/src/features/student/templates/StudentsTemplate/index.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 const StudentsTemplate = ({ students, max }: Props) => {
-  const { isSuccess } = useLoggedIn()
+  const { isSuccess } = useLoggedIn({})
   const { onLogout } = useLogout()
   const { onWithdraw } = useWithdraw()
 

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -6,10 +6,12 @@ import useModal from '@features/student/hooks/useModal'
 import { useSelector } from 'react-redux'
 import { RootState } from '@store'
 import useStudentDetail from '@features/student/hooks/useStudentDetail'
+import useLoggedIn from '@features/auth/hook/useLoggedIn'
 
 export default function Home() {
   const { data } = useStudent()
   const { isShow } = useModal()
+  useLoggedIn({})
   useStudentDetail()
 
   const { studentDetail } = useSelector((state: RootState) => ({

--- a/packages/app/src/pages/login.tsx
+++ b/packages/app/src/pages/login.tsx
@@ -3,7 +3,7 @@ import useLoggedIn from '@features/auth/hook/useLoggedIn'
 import LoginTemplate from '@templates/LoginTemplate'
 
 const Login = () => {
-  useLoggedIn()
+  useLoggedIn({ redirectToIfFound: '/' })
 
   return (
     <>

--- a/packages/app/src/pages/register.tsx
+++ b/packages/app/src/pages/register.tsx
@@ -3,7 +3,8 @@ import { RegisterForm } from '@features/register/organisms'
 import RegisterLayout from '@layouts/RegisterLayout'
 
 const Register = () => {
-  useLoggedIn()
+  useLoggedIn({ redirectTo: '/', redirectToIfFound: '/' })
+
   return (
     <RegisterLayout>
       <RegisterForm />


### PR DESCRIPTION
## 💡 개요

전 useLoggedIn 로직은 너무 복잡하고 확장성도 너무 낮아 수정을 진행했습니다

## 📃 작업내용

- useLoggedIn에서 props로 redirectTo와 redirectToIfFound받아서 처리하도록 수정했습니다
   - redirectTo는 로그인이 되지 않은 상태에서 페이지에 접근하면 어디로 보낼지를 적습니다
   - redirectToIfFound는 로그인이 된 상태에서 페이지 접근을 막을 때 사용합니다
   - 하지만 `/register`는 예외로 isExist가 false 일때만 접근 가능하게 했습니다
   - 두 props는 모두 옵셔널이어서 언제나 접근이 가능한 페이지는 아무것도 넘겨주지 않아도 됩니다

## 🔀 변경사항

- 로그아웃 또는 회원 탈퇴를 진행한 후에도 loggedIn값이 변경되지 않아서 api 요청 이후에 refetchLoggedIn을 실행해 값을 초기화 해주었습니다