### PR TITLE
[#124] 로그인 페이지 반응형 구현

### DIFF
--- a/packages/app/src/features/auth/components/GuestLink.tsx
+++ b/packages/app/src/features/auth/components/GuestLink.tsx
@@ -6,18 +6,27 @@ interface Props {
   children: ReactNode
 }
 
-const Wrapper = styled.a`
+const Wrapper = styled.div`
+  width: 100%;
+  text-align: center;
+  margin-top: 1rem;
+`
+
+const Link = styled.a`
   ${({ theme }) => theme.body2}
   color: var(--WHITE);
   text-decoration: underline;
-  display: block;
+  display: inline;
   text-align: center;
-  margin-top: 1rem;
   cursor: pointer;
 `
 
 const GuestLink = ({ children, href }: Props) => {
-  return <Wrapper href={href}>{children}</Wrapper>
+  return (
+    <Wrapper>
+      <Link href={href}>{children}</Link>
+    </Wrapper>
+  )
 }
 
 export default GuestLink

--- a/packages/app/src/features/auth/components/GuestLink.tsx
+++ b/packages/app/src/features/auth/components/GuestLink.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled'
-import Link from 'next/link'
 import { ReactNode } from 'react'
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   children: ReactNode
 }
 
-const Wrapper = styled(Link)`
+const Wrapper = styled.a`
   ${({ theme }) => theme.body2}
   color: var(--WHITE);
   text-decoration: underline;

--- a/packages/app/src/features/register/hooks/useRegister.tsx
+++ b/packages/app/src/features/register/hooks/useRegister.tsx
@@ -8,11 +8,11 @@ import {
   PostStudentInfoService,
   PostFileService,
 } from '@features/register/services'
-import { useRouter } from 'next/router'
+import useLoggedIn from '@features/auth/hook/useLoggedIn'
 
 const useRegister = () => {
   const { addToast } = useToast()
-  const router = useRouter()
+  const { refetchLoggedIn } = useLoggedIn({})
   const {
     register,
     control,
@@ -66,7 +66,9 @@ const useRegister = () => {
     if (res) return addToast('error', ErrorMapper(res, apiErrors))
 
     addToast('success', '학생 정보 기입에 성공했습니다')
-    router.push('/')
+    await refetchLoggedIn()
+
+    window.location.href = '/'
   })
 
   return {

--- a/packages/app/src/templates/LoginTemplate/index.tsx
+++ b/packages/app/src/templates/LoginTemplate/index.tsx
@@ -8,15 +8,9 @@ const LoginTemplate = () => {
 
   return (
     <S.Wrapper>
-      <S.Video muted autoPlay loop>
-        <source
-          src='/video/login-background.mp4'
-          type='video/mp4; codecs=hvc1'
-        />
-        <source
-          src='/video/login-background.webm'
-          type='video/mp4;codecs="avc1.42E01E, mp4a.40.2"'
-        />
+      <S.Video muted autoPlay playsInline loop>
+        <source src='/video/login-background.webm' type='video/webm' />
+        <source src='/video/login-background.mp4' type='video/mp4' />
       </S.Video>
       <FadeinAnimation>
         <Headline type='headline1'>{'STUDENT\nMANAGEMENT SERVICE'}</Headline>

--- a/packages/app/src/templates/LoginTemplate/style.ts
+++ b/packages/app/src/templates/LoginTemplate/style.ts
@@ -3,7 +3,6 @@ import styled from '@emotion/styled'
 export const Wrapper = styled.main`
   padding-top: 8rem;
   width: 100%;
-  height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/packages/shared/src/atoms/Toast/style.ts
+++ b/packages/shared/src/atoms/Toast/style.ts
@@ -36,7 +36,7 @@ export const Wrapper = styled.span<WrapperProps>`
   position: relative;
   height: min-content;
   margin: 0 auto;
-  padding: 1.5rem 1.25rem;
+  padding: 0.5rem 1rem;
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
@@ -53,6 +53,7 @@ export const Wrapper = styled.span<WrapperProps>`
 `
 
 export const Comment = styled.div`
-  ${({ theme }) => theme.body1}
+  ${({ theme }) => theme.body2}
   color: var(--WHITE);
+  white-space: pre;
 `


### PR DESCRIPTION
## 💡 개요

모바일에서 로그인 페이지에 접속하면 영상 재생도 막히고 반응형도 이상한 문제가 있었습니다

<img width="375" alt="image" src="https://github.com/GSM-MSG/SMS-FrontEnd/assets/57276315/b0355674-8c15-42bf-a518-3971b2979550">


## 📃 작업내용

- 반응형을 위해 100vh를 사용하는 코드를 제거했습니다
- iOS 환경에서는 webm을 지원하지 않을 뿐더러 자동재생도 막힌다는 걸 알고 mp4를 추가한 후에 자동 재생 옵션을 추가했습니다

<img width="375" alt="image" src="https://github.com/GSM-MSG/SMS-FrontEnd/assets/57276315/f23b5da5-cabf-4508-9998-042a63e8a9d7">

## 🔀 변경사항

- toast style을 수정했습니다
- 회원 가입 이후 처리를 수정했습니다

## 🎸 기타

절전 모드에서는 영상 자동재생이 완전히 막힙니다
