### PR TITLE
[#163] scrollbar 제거

### DIFF
--- a/packages/shared/src/style/global.css
+++ b/packages/shared/src/style/global.css
@@ -35,3 +35,7 @@ body,
 #__next {
   height: 100%;
 }
+
+*::-webkit-scrollbar {
+  width: 0;
+}


### PR DESCRIPTION
## 💡 개요

콘텐츠를 망치는 scrollbar를 지웠습니다

## 📃 작업내용

- 스크롤바를 추가하면 스크롤바 크기인 16px이 padding으로 오른쪽에서 밀려나는 문제가 있었습니다
- 이것 저것 시도해 봤지만 스크롤바를 지우는 게 가장 쉬운 방법이었습니다

## 🙋‍♂️ 질문사항

- 어떻게 하면 스크롤바가 필요 없는 곳에선 스크롤바가 안 뜨고 필요한 곳에서는 뜨게 할 수 있을까?