### PR TITLE
[#187] MultiMonthPicker 진행중 checkbox 추가

### DIFF
--- a/packages/app/src/features/register/molecules/ProjectsInput/index.tsx
+++ b/packages/app/src/features/register/molecules/ProjectsInput/index.tsx
@@ -135,7 +135,10 @@ const ProjectsInput = ({
                     { required: { value: true, message: '필수 값입니다' } }
                   )}
                   endDateRegister={register(`projects.${idx}.inProgress.end`, {
-                    required: { value: true, message: '필수 값입니다' },
+                    required: {
+                      value: watch(`projects.${idx}.inProgress.end`) !== null,
+                      message: '필수 값입니다',
+                    },
                   })}
                   onChangeStartDate={(value) =>
                     setValue(`projects.${idx}.inProgress.start`, value)

--- a/packages/shared/src/atoms/MonthPicker/index.tsx
+++ b/packages/shared/src/atoms/MonthPicker/index.tsx
@@ -20,7 +20,7 @@ interface Props
 }
 
 const MonthPicker = forwardRef<HTMLInputElement, Props>(
-  ({ value, setValue, error, clearError, ...props }, ref) => {
+  ({ value, setValue, error, clearError, disabled, ...props }, ref) => {
     const [isShow, setIsShow] = useState<boolean>(false)
 
     const onChange = (value: string) => {
@@ -30,8 +30,9 @@ const MonthPicker = forwardRef<HTMLInputElement, Props>(
 
     return (
       <S.Wrapper>
-        <input {...props} ref={ref} hidden />
+        <input {...props} disabled={disabled} ref={ref} hidden />
         <S.MonthInput
+          style={{ cursor: disabled ? 'auto' : 'pointer' }}
           onClick={(e) => {
             e.stopPropagation()
             setIsShow(true)
@@ -39,7 +40,7 @@ const MonthPicker = forwardRef<HTMLInputElement, Props>(
         >
           <S.Text>{value || 'yyyy.mm'}</S.Text>
           <Icon.Calendar />
-          {isShow && (
+          {isShow && !disabled && (
             <Modal
               value={value}
               onChange={onChange}

--- a/packages/shared/src/molecules/MultiMonthPicker/index.stories.tsx
+++ b/packages/shared/src/molecules/MultiMonthPicker/index.stories.tsx
@@ -12,7 +12,7 @@ export default config
 
 interface FormType {
   startDate: string
-  endDate: string
+  endDate: string | null
 }
 
 export const Primary = () => {
@@ -23,9 +23,11 @@ export const Primary = () => {
     clearErrors,
     setValue,
     formState: { errors },
-  } = useForm<FormType>()
+  } = useForm<FormType>({
+    defaultValues: { endDate: undefined },
+  })
 
-  const onSubmit = handleSubmit(() => {})
+  const onSubmit = handleSubmit(console.log)
 
   return (
     <form onSubmit={onSubmit}>
@@ -34,7 +36,10 @@ export const Primary = () => {
           required: { value: true, message: '필수 값입니다' },
         })}
         endDateRegister={register('endDate', {
-          required: { value: true, message: '필수 값입니다' },
+          required: {
+            value: watch('endDate') !== null,
+            message: '필수 값입니다',
+          },
         })}
         startDate={watch('startDate')}
         endDate={watch('endDate')}

--- a/packages/shared/src/molecules/MultiMonthPicker/index.stories.tsx
+++ b/packages/shared/src/molecules/MultiMonthPicker/index.stories.tsx
@@ -27,7 +27,7 @@ export const Primary = () => {
     defaultValues: { endDate: undefined },
   })
 
-  const onSubmit = handleSubmit(console.log)
+  const onSubmit = handleSubmit(() => {})
 
   return (
     <form onSubmit={onSubmit}>

--- a/packages/shared/src/molecules/MultiMonthPicker/index.tsx
+++ b/packages/shared/src/molecules/MultiMonthPicker/index.tsx
@@ -1,6 +1,6 @@
 import { UseFormRegisterReturn } from 'react-hook-form'
-import { forwardRef } from 'react'
-import { MonthPicker } from '../../atoms'
+import { forwardRef, useState } from 'react'
+import { Checkbox, MonthPicker } from '../../atoms'
 import * as Icon from '../../icons'
 import * as S from './style'
 
@@ -10,7 +10,7 @@ interface Props {
   startDate: string
   endDate: string | null
   onChangeStartDate: (value: string) => void
-  onChangeEndDate: (value: string) => void
+  onChangeEndDate: (value: string | null) => void
   startDateError?: string
   endDateError?: string
   clearErrorStartDate: () => void
@@ -33,6 +33,16 @@ const MultiMonthPicker = forwardRef<HTMLDivElement, Props>(
     },
     ref
   ) => {
+    const [inProgress, setInProgress] = useState<boolean>(false)
+
+    const onChange = () => {
+      if (!inProgress) onChangeEndDate(null)
+      else onChangeEndDate('')
+
+      clearErrorEndDate()
+      setInProgress(!inProgress)
+    }
+
     return (
       <div ref={ref}>
         <S.Inputs>
@@ -47,6 +57,7 @@ const MultiMonthPicker = forwardRef<HTMLDivElement, Props>(
           </S.IconWrapper>
           <MonthPicker
             {...endDateRegister}
+            disabled={inProgress}
             value={endDate || ''}
             setValue={onChangeEndDate}
             clearError={clearErrorEndDate}
@@ -59,6 +70,12 @@ const MultiMonthPicker = forwardRef<HTMLDivElement, Props>(
             <S.Error>{endDateError}</S.Error>
           </S.Errors>
         )}
+
+        <S.CheckboxWrapper>
+          <Checkbox checked={inProgress} onChange={onChange}>
+            진행중
+          </Checkbox>
+        </S.CheckboxWrapper>
       </div>
     )
   }

--- a/packages/shared/src/molecules/MultiMonthPicker/style.ts
+++ b/packages/shared/src/molecules/MultiMonthPicker/style.ts
@@ -23,3 +23,8 @@ export const IconWrapper = styled.div`
   width: 1.5rem;
   height: 1.5rem;
 `
+
+export const CheckboxWrapper = styled.div`
+  display: flex;
+  margin-top: 0.5rem;
+`


### PR DESCRIPTION
## 💡 개요

- MultiMonthPicker에 진행중 checkbox를 추가했습니다

## 📃 작업내용

- MultiMonthPicker에 진행중 checkbox를 추가해 check되면 endDate 값이 null 되도록 했습니다
- check시 모달도 안 띄워지게 처리했습니다
- react hook form의 register에서 null을 허용 하도록 변경해야지 잘 동작해서 register 코드를 조금 수정했습니다

<img width="685" alt="image" src="https://github.com/GSM-MSG/SMS-FrontEnd/assets/57276315/5ad37d45-68a6-4b45-b6b7-7219807dc262">