### PR TITLE
[#200] 토큰 재발급 로직 추가

### DIFF
--- a/packages/app/src/api/CustomBaseQuery.ts
+++ b/packages/app/src/api/CustomBaseQuery.ts
@@ -2,7 +2,7 @@ import { BaseQueryFn, FetchBaseQueryMeta } from '@reduxjs/toolkit/query/react'
 import { AxiosError, AxiosRequestConfig, isAxiosError } from 'axios'
 import axiosApi from './axiosApi'
 
-const CutomBaseQuery: BaseQueryFn<
+const CustomBaseQuery: BaseQueryFn<
   AxiosRequestConfig,
   unknown,
   AxiosError | string,
@@ -21,4 +21,4 @@ const CutomBaseQuery: BaseQueryFn<
   }
 }
 
-export default CutomBaseQuery
+export default CustomBaseQuery

--- a/packages/app/src/api/rtkApi.ts
+++ b/packages/app/src/api/rtkApi.ts
@@ -1,7 +1,8 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { createApi } from '@reduxjs/toolkit/query/react'
+import CustomBaseQuery from './CustomBaseQuery'
 
 const rtkApi = createApi({
-  baseQuery: fetchBaseQuery(),
+  baseQuery: CustomBaseQuery,
   tagTypes: ['Student', 'My'],
   endpoints: () => ({}),
 })

--- a/packages/app/src/features/auth/hook/useAuth.tsx
+++ b/packages/app/src/features/auth/hook/useAuth.tsx
@@ -3,12 +3,22 @@ import env from '@lib/env'
 import { useEffect, useState } from 'react'
 import login from '@features/auth/service/login'
 import { useToast } from '@features/toast'
+import useLocalStorage from '@features/global/hooks/useLocalStorage'
+import Token from '@lib/Token'
 
 const useAuth = () => {
   const router = useRouter()
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const code = router.query.code?.toString() || ''
   const { addToast } = useToast()
+  const [_, setAccessExpires] = useLocalStorage<string | undefined>(
+    Token.ACCESS_TOKEN_EXP,
+    undefined
+  )
+  const [__, setRefreshExpires] = useLocalStorage<string | undefined>(
+    Token.REFRESH_TOKEN_EXP,
+    undefined
+  )
 
   useEffect(() => {
     if (!code) return
@@ -21,6 +31,8 @@ const useAuth = () => {
         return addToast('error', res)
       }
 
+      setAccessExpires(res.accessTokenExp)
+      setRefreshExpires(res.refreshTokenExp)
       addToast('success', '로그인에 성공했습니다')
       await router.push(res.isExist ? '/' : '/register')
       setIsLoading(false)

--- a/packages/app/src/features/auth/hook/useAutoReissue.tsx
+++ b/packages/app/src/features/auth/hook/useAutoReissue.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react'
+import reissue from '@features/auth/service/reissue'
+import useLocalStorage from '@features/global/hooks/useLocalStorage'
+import Token from '@lib/Token'
+
+const useAutoReissue = () => {
+  const [access, setAccess] = useLocalStorage<string>(
+    Token.ACCESS_TOKEN_EXP,
+    ''
+  )
+  const [refresh, setRefresh] = useLocalStorage<string>(
+    Token.REFRESH_TOKEN_EXP,
+    ''
+  )
+
+  useEffect(() => {
+    if (!access && !refresh) return
+    if (new Date(refresh) <= new Date()) {
+      setAccess('')
+      return
+    }
+
+    const beforeMinute = access
+      ? new Date(access).getTime() - new Date().getTime() - 10000
+      : 0
+
+    const timeout = setTimeout(async () => {
+      const res = await reissue()
+      if (!res) setAccess('')
+
+      setAccess(res?.accessTokenExp || '')
+      setRefresh(res?.refreshTokenExp || '')
+    }, beforeMinute)
+
+    return () => clearTimeout(timeout)
+  }, [access])
+}
+
+export default useAutoReissue

--- a/packages/app/src/features/auth/lib/createSetCookie.ts
+++ b/packages/app/src/features/auth/lib/createSetCookie.ts
@@ -1,0 +1,24 @@
+import Token from '@lib/Token'
+import { TokenResponse } from '@features/auth/type/TokenResponse'
+
+export const createSetCookie = (data: TokenResponse) => {
+  const accessToken = createCookie(
+    Token.ACCESS_TOKEN,
+    data.accessToken,
+    data.accessTokenExp
+  )
+  const refreshToken = createCookie(
+    Token.REFRESH_TOKEN,
+    data.refreshToken,
+    data.refreshTokenExp
+  )
+
+  return [refreshToken, accessToken]
+}
+
+export const createCookie = (name: string, token: string, expired: string) => {
+  const secure = process.env.NODE_ENV === 'production' ? 'secure;' : ''
+  const UTCDate = new Date(expired).toUTCString()
+
+  return `${name}=${token}; path=/; expires=${UTCDate}; httpOnly; ${secure} domain=localhost`
+}

--- a/packages/app/src/features/auth/service/login.ts
+++ b/packages/app/src/features/auth/service/login.ts
@@ -5,7 +5,7 @@ import errors from '@features/auth/errors'
 
 const login = async (code: string) => {
   try {
-    const { data } = await axiosApi.post<TokenResponse>('/server/auth', {
+    const { data } = await axiosApi.post<TokenResponse>('/api/login', {
       code,
     })
 

--- a/packages/app/src/features/auth/service/reissue.ts
+++ b/packages/app/src/features/auth/service/reissue.ts
@@ -1,19 +1,9 @@
 import { ReissueResponse } from '@features/auth/type/TokenResponse'
-import env from '@lib/env'
 import axios from 'axios'
 
-const reissue = async (refreshToken: string) => {
+const reissue = async () => {
   try {
-    const { data } = await axios.patch<ReissueResponse>(
-      '/server/auth',
-      {},
-      {
-        headers: {
-          'Refresh-Token': refreshToken,
-        },
-        baseURL: env.NEXT_PUBLIC_SERVER_URL,
-      }
-    )
+    const { data } = await axios.patch<ReissueResponse>('/api/reissue')
 
     return data
   } catch (e) {

--- a/packages/app/src/features/global/hooks/useLocalStorage.tsx
+++ b/packages/app/src/features/global/hooks/useLocalStorage.tsx
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const useLocalStorage = <T,>(
+  key: string,
+  initialValue: T
+): [T, (value: T) => void] => {
+  const [storedValue, setStoredValue] = useState<T>(initialValue)
+
+  useEffect(() => {
+    try {
+      const item = localStorage.getItem(key)
+      item && setStoredValue(JSON.parse(item))
+    } catch (e) {
+      console.error(e)
+    }
+  }, [])
+
+  const setValue = useCallback(
+    (value: T) => {
+      try {
+        localStorage.setItem(key, JSON.stringify(value))
+        setStoredValue(value)
+      } catch (e) {
+        console.error(e)
+      }
+    },
+    [key]
+  )
+
+  return [storedValue, setValue]
+}
+
+export default useLocalStorage

--- a/packages/app/src/pages/_app.tsx
+++ b/packages/app/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import { Provider } from 'react-redux'
 import GlobalLayout from '@layouts/GlobalLayout'
 import { ToastContainer } from '@features/toast'
 import { ModalProvider } from '@features/modal/providers'
+import useAutoReissue from '@features/auth/hook/useAutoReissue'
 import wrapper from '@store'
 import type { AppProps } from 'next/app'
 
@@ -10,6 +11,7 @@ import '@styles/font.css'
 
 export default function App({ Component, ...rest }: AppProps) {
   const { store, props } = wrapper.useWrappedStore(rest)
+  useAutoReissue()
 
   return (
     <Provider store={store}>

--- a/packages/app/src/pages/api/login.ts
+++ b/packages/app/src/pages/api/login.ts
@@ -1,0 +1,46 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { axiosApi } from '@api'
+import env from '@lib/env'
+import Token from '@lib/Token'
+import { TokenResponse } from '@features/auth/type/TokenResponse'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST')
+    return res.status(400).json({ message: 'not found page' })
+  const code = req.body.code
+  if (!code) return res.status(400).json({ message: 'not found code' })
+
+  try {
+    const { data } = await axiosApi.post<TokenResponse>(
+      `${env.NEXT_PUBLIC_SERVER_URL}/auth`,
+      { code }
+    )
+    res.status(200).setHeader('Set-Cookie', createSetCookie(data)).json(data)
+  } catch (e) {
+    res.status(500).json({ message: 'Server Error' })
+  }
+}
+
+const createSetCookie = (data: TokenResponse) => {
+  const accessToken = createCookie(
+    Token.ACCESS_TOKEN,
+    data.accessToken,
+    data.accessTokenExp
+  )
+  const refreshToken = createCookie(
+    Token.REFRESH_TOKEN,
+    data.refreshToken,
+    data.refreshTokenExp
+  )
+
+  return [refreshToken, accessToken]
+}
+
+const createCookie = (name: string, token: string, expired: string) => {
+  const secure = process.env.NODE_ENV === 'production' ? 'secure;' : ''
+
+  return `${name}=${token}; path=/; expires=${expired}; httpOnly; ${secure} domain=localhost`
+}

--- a/packages/app/src/pages/api/reissue.ts
+++ b/packages/app/src/pages/api/reissue.ts
@@ -3,20 +3,21 @@ import { axiosApi } from '@api'
 import env from '@lib/env'
 import { TokenResponse } from '@features/auth/type/TokenResponse'
 import { createSetCookie } from '@features/auth/lib/createSetCookie'
+import Token from '@lib/Token'
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  if (req.method !== 'POST')
+  if (req.method !== 'PATCH')
     return res.status(400).json({ message: 'not found page' })
-  const code = req.body.code
-  if (!code) return res.status(400).json({ message: 'not found code' })
+  const refreshToken = req.cookies[Token.REFRESH_TOKEN]
 
   try {
-    const { data } = await axiosApi.post<TokenResponse>(
+    const { data } = await axiosApi.patch<TokenResponse>(
       `${env.NEXT_PUBLIC_SERVER_URL}/auth`,
-      { code }
+      {},
+      { headers: { 'Refresh-Token': refreshToken } }
     )
     res.status(200).setHeader('Set-Cookie', createSetCookie(data)).json(data)
   } catch (e) {


### PR DESCRIPTION
## 💡 개요

cookie를 사용하게 되면서 기존 토큰 재발급 로직을 수정했습니다

## 📃 작업내용

- 쿠키가 클라에 저장되지 않는 게 보이지 않아서 직접 쿠키를 넣어줬습니다. 로그인과 토큰 재발급 요청을 수정함
- 토큰 재발급을 api 요청할 때 진행하는 것이 아닌 setTimeout을 통해 시간이 지나면 하도록 변경했습니다