### PR TITLE
[#237] 연속 요척을 막는 처리 추가

### DIFF
--- a/packages/app/src/features/auth/hook/useAuth.tsx
+++ b/packages/app/src/features/auth/hook/useAuth.tsx
@@ -11,7 +11,7 @@ const useAuth = () => {
   const router = useRouter()
   const code = router.query.code?.toString() || ''
   const { addToast } = useToast()
-  const { loadingWrap } = useLoading()
+  const { loadingWrap, loadingClose } = useLoading()
   const [_, setAccessExpires] = useLocalStorage(Token.ACCESS_TOKEN_EXP, '')
   const [__, setRefreshExpires] = useLocalStorage(Token.REFRESH_TOKEN_EXP, '')
 
@@ -28,6 +28,7 @@ const useAuth = () => {
       setRefreshExpires(res.refreshTokenExp)
       addToast('success', '로그인에 성공했습니다')
       await router.push(res.isExist ? '/' : '/register')
+      loadingClose()
     })()
   }, [code])
 

--- a/packages/app/src/features/modal/hooks/useLoading.tsx
+++ b/packages/app/src/features/modal/hooks/useLoading.tsx
@@ -5,15 +5,20 @@ import { show, close } from '@features/modal/stores/modalSlice'
 const useLoading = () => {
   const dispatch = useDispatch()
 
-  const loadingWrap = async <T,>(callback: Promise<T>) => {
+  const loadingClose = () => dispatch(close())
+
+  const loadingWrap = async <T,>(
+    callback: Promise<T>,
+    immediatelyClose?: boolean
+  ) => {
     dispatch(show(<LoadingPortal />))
     const res = await callback
-    dispatch(close())
+    if (immediatelyClose) loadingClose()
 
     return res
   }
 
-  return { loadingWrap }
+  return { loadingWrap, loadingClose }
 }
 
 export default useLoading

--- a/packages/app/src/features/register/hooks/useImageUpload.tsx
+++ b/packages/app/src/features/register/hooks/useImageUpload.tsx
@@ -24,7 +24,8 @@ const useImageUpload = ({ setValue, setError, clearError }: Props) => {
     const file = e.target.files[0]
 
     const imageUrl = await loadingWrap(
-      PostFileService(file, file.type.includes('image'))
+      PostFileService(file, file.type.includes('image')),
+      true
     )
 
     if (!imageUrl) return showErrorMessage('파일 업로드에 실패했습니다')

--- a/packages/app/src/features/register/hooks/useRegister.tsx
+++ b/packages/app/src/features/register/hooks/useRegister.tsx
@@ -11,7 +11,7 @@ import useLoading from '@features/modal/hooks/useLoading'
 const useRegister = () => {
   const { addToast } = useToast()
   const router = useRouter()
-  const { loadingWrap } = useLoading()
+  const { loadingWrap, loadingClose } = useLoading()
   const { refetchLoggedIn } = useLoggedIn({})
   const {
     register,
@@ -51,6 +51,7 @@ const useRegister = () => {
 
     router.push('/')
 
+    loadingClose()
     addToast('success', '학생 정보 기입에 성공했습니다')
     await refetchLoggedIn()
   })

--- a/packages/app/src/features/student/hooks/useModifyProfile.tsx
+++ b/packages/app/src/features/student/hooks/useModifyProfile.tsx
@@ -27,7 +27,7 @@ const useModifyProfile = ({ defaultValue }: Props) => {
     },
   })
   const { addToast } = useToast()
-  const { loadingWrap } = useLoading()
+  const { loadingWrap, loadingClose } = useLoading()
   const router = useRouter()
   const [mutation] = profileImgApi.useRefetchProfileImgMutation()
 
@@ -38,6 +38,7 @@ const useModifyProfile = ({ defaultValue }: Props) => {
       return addToast('error', errorMessage)
     }
     await router.push('/')
+    loadingClose()
     mutation()
 
     addToast('success', '정보 수정에 성공했습니다')


### PR DESCRIPTION
## 💡 개요

submit 버튼을 연타할 경우 데이터가 두 번 날라갈 수 있는 문제가 있습니다
이를 해결하기 위해 페이지가 옮겨진 후에 로딩 페이지를 닫게 하도록 변경했습니다

## 📃 작업내용

- useLoading 훅에서 로딩 모달을 바로 닫지 않게 하다가 loadingClose를 실행하면 닫히도록 변경했습니다
- useLoading을 사용하는 hook들은 url을 변경한 후에 loadingClose를 실행하도록 변경했습니다

## 🎸 기타

redirect를 useLoading 훅에서도 처리하면 좋을 것 같다는 생각이 들지만
귀찮기도 하고 잘 모르겠고 loadingWrap의 response 타입 관리도 귀찮아서 다음으로 미루도록 하겠습니다