### PR TITLE
[#247] 무한 스크롤 오류 해결

### DIFF
--- a/packages/app/src/features/student/hooks/useStudent.tsx
+++ b/packages/app/src/features/student/hooks/useStudent.tsx
@@ -42,6 +42,7 @@ const useStudent = () => {
     dispatch(actions.setTotoalSize(data.totalSize))
     if (data?.content) dispatch(actions.addStudents(data.content))
     if (data.last) return dispatch(actions.nextStop())
+    dispatch(actions.nextPage())
   }
 
   const setStudentList = (


### PR DESCRIPTION
## 💡 개요

page1을 계속해서 가져오는 문제가 발생했습니다
때문에 학생 21명 이상만 있으면 진짜 평생 무한 스크롤이 가능해 지게 되었습니다

## 📃 작업내용

무한 스크롤 이후 page값을 카운트 하도록 변경했습니다