### PR TITLE
[#245] 학생 정보 기입 폼 조건 수정

### DIFF
--- a/packages/app/src/features/register/atoms/InputColumn/style.ts
+++ b/packages/app/src/features/register/atoms/InputColumn/style.ts
@@ -4,6 +4,7 @@ export const Wrapper = styled.div`
   display: grid;
   grid-template-columns: 1fr 3fr;
   margin-bottom: 1.25rem;
+  white-space: pre-wrap;
 
   @media (max-width: 30rem) {
     display: flex;
@@ -15,4 +16,5 @@ export const Wrapper = styled.div`
 export const Comment = styled.p`
   ${({ theme }) => theme.body1}
   color: var(--N40);
+  white-space: pre-wrap;
 `

--- a/packages/app/src/features/register/atoms/LinkMultiDoubleInput/index.tsx
+++ b/packages/app/src/features/register/atoms/LinkMultiDoubleInput/index.tsx
@@ -33,9 +33,17 @@ const LinkMultiDoubleInput = ({ index, control, register, errors }: Props) => {
             key={field.id}
             titleRegister={register(`projects.${index}.links.${idx}.name`, {
               required: { value: true, message: '필수 값입니다' },
+              maxLength: {
+                value: 50,
+                message: '최대 50자까지 가능합니다',
+              },
             })}
             contentRegister={register(`projects.${index}.links.${idx}.url`, {
               required: { value: true, message: '필수 값입니다' },
+              maxLength: {
+                value: 5000,
+                message: '최대 5000자까지 가능합니다',
+              },
             })}
             titleError={errors?.projects?.[index]?.links?.[idx]?.name?.message}
             contentError={errors?.projects?.[index]?.links?.[idx]?.url?.message}

--- a/packages/app/src/features/register/molecules/PrizeInputs/index.tsx
+++ b/packages/app/src/features/register/molecules/PrizeInputs/index.tsx
@@ -45,6 +45,10 @@ const PrizeInputs = ({
                 <Input
                   {...register(`prizes.${idx}.name`, {
                     required: { value: true, message: '필수 값입니다' },
+                    maxLength: {
+                      value: 40,
+                      message: '최대 40자까지 가능합니다',
+                    },
                   })}
                   placeholder='수상 내역 이름입력'
                   error={errors?.prizes?.[idx]?.name?.message}
@@ -55,6 +59,10 @@ const PrizeInputs = ({
                 <Input
                   {...register(`prizes.${idx}.kind`, {
                     required: { value: true, message: '필수 값입니다' },
+                    maxLength: {
+                      value: 20,
+                      message: '최대 20자까지 가능합니다',
+                    },
                   })}
                   placeholder='수상 종류입력'
                   error={errors?.prizes?.[idx]?.kind?.message}

--- a/packages/app/src/features/register/molecules/ProfileInputs/index.tsx
+++ b/packages/app/src/features/register/molecules/ProfileInputs/index.tsx
@@ -111,9 +111,7 @@ const ProfileInputs = ({
           value={watch('techStacks')}
           limit={5}
           control={control}
-          register={register('techStacks', {
-            required: { value: true, message: '1개 이상은 입력해야 합니다' },
-          })}
+          register={register('techStacks')}
           error={errors.techStacks?.message}
         />
       </InputColumn>

--- a/packages/app/src/features/register/molecules/ProjectsInput/index.tsx
+++ b/packages/app/src/features/register/molecules/ProjectsInput/index.tsx
@@ -72,7 +72,11 @@ const ProjectsInput = ({
                   {...register(`projects.${idx}.name`, {
                     required: {
                       value: true,
-                      message: '1개 이상은 입력해야 합니다',
+                      message: '필수 값입니다',
+                    },
+                    maxLength: {
+                      value: 30,
+                      message: '최대 30자까지 가능합니다',
                     },
                   })}
                   placeholder='프로젝트 이름입력'
@@ -114,6 +118,10 @@ const ProjectsInput = ({
                 <Input
                   {...register(`projects.${idx}.description`, {
                     required: { value: true, message: '필수 값입니다' },
+                    maxLength: {
+                      value: 1000,
+                      message: '최대 1000자까지 가능합니다',
+                    },
                   })}
                   placeholder='프로젝트 내용입력'
                   error={errors.projects?.[idx]?.description?.message}
@@ -139,6 +147,10 @@ const ProjectsInput = ({
                 <Input
                   {...register(`projects.${idx}.myActivity`, {
                     required: { value: true, message: '필수 값입니다' },
+                    maxLength: {
+                      value: 1000,
+                      message: '최대 1000자까지 가능합니다',
+                    },
                   })}
                   placeholder='주요 작업 내용서술'
                   error={errors.projects?.[idx]?.myActivity?.message}

--- a/packages/app/src/features/register/molecules/SchoolInputs/index.tsx
+++ b/packages/app/src/features/register/molecules/SchoolInputs/index.tsx
@@ -16,11 +16,11 @@ interface Props {
 const SchoolInputs = ({ register, errors, resetField }: Props) => {
   return (
     <FormWrapper title='학교 생활'>
-      <InputColumn comment='인증제 점수'>
+      <InputColumn comment={`인증제 점수\n(최대 9999점)`}>
         <Input
           {...register('gsmAuthenticationScore', {
             required: { value: true, message: '필수 값입니다' },
-            max: { value: 3000, message: '최대 3000점 까지 가능합니다' },
+            max: { value: 9999, message: '최대 9999점 까지 가능합니다' },
             valueAsNumber: true,
           })}
           placeholder='인증 점수 입력'

--- a/packages/app/src/features/register/molecules/WorkingInputs/index.tsx
+++ b/packages/app/src/features/register/molecules/WorkingInputs/index.tsx
@@ -42,7 +42,7 @@ const WorkingInputs = ({
           type='number'
           {...register('salary', {
             required: { value: true, message: '필수 값입니다' },
-            max: { value: 10000, message: '희망 연봉은 최대 10000까지 됩니다' },
+            max: { value: 9999, message: '희망 연봉은 최대 9999까지 됩니다' },
             valueAsNumber: true,
           })}
           error={errors.salary?.message}

--- a/packages/app/src/features/register/molecules/WorkingInputs/index.tsx
+++ b/packages/app/src/features/register/molecules/WorkingInputs/index.tsx
@@ -42,7 +42,7 @@ const WorkingInputs = ({
           type='number'
           {...register('salary', {
             required: { value: true, message: '필수 값입니다' },
-            max: { value: 9999, message: '희망 연봉은 최대 9999까지 됩니다' },
+            max: { value: 10000, message: '희망 연봉은 최대 10000까지 됩니다' },
             valueAsNumber: true,
           })}
           error={errors.salary?.message}

--- a/packages/shared/src/molecules/SearchInput/index.tsx
+++ b/packages/shared/src/molecules/SearchInput/index.tsx
@@ -90,6 +90,7 @@ const SearchInput = ({
           onKeyDown={onKeyDownEnter}
           onKeyUp={onKeyUpEnter}
           error={error}
+          maxLength={30}
         />
 
         {!hasTechStack() && (


### PR DESCRIPTION
## 💡 개요

학생 정보 기입 부분에 기본 조건이 변경되었습니다

## 🔀 변경사항

- projects.name 에 30자 제한을 추가했습니다
- projects.links.url에 5000자 제한을 추가했습니다
- projects.links.name 에 30자 제한을 추가했습니다
- projects.description에 1000자 제한을 추가했습니다
- projects.myActivity에 1000자 제한을 추가했습니다
- prizes.name에 40자 제한을 추가했습니다
- prizes.kind에 20자 제한을 추가했습니다
- techStacks에 1개 이상 제한을 풀었습니다
- gsmAuthenticationScore를 기존 3000점에서 9999점으로 변경했습니다
- techStacks의 각각의 기술들의 길이를 30자로 줄였습니다