### PR TITLE
[#275] skeleton ui 버그 해결 및 로직 수정

### DIFF
--- a/packages/app/src/features/student/hooks/useStudent.tsx
+++ b/packages/app/src/features/student/hooks/useStudent.tsx
@@ -15,11 +15,12 @@ interface StudentsParams extends StudentParam {
 const useStudent = () => {
   const dispatch = useDispatch()
   const { addToast } = useToast()
-  const { studentParam, studentList, totalSize } = useSelector(
+  const { studentParam, studentList, totalSize, nextStop } = useSelector(
     (state: RootState) => ({
       studentParam: state.studentParam,
       studentList: state.studentList.studentList,
       totalSize: state.studentList.totalSize,
+      nextStop: state.studentParam.nextStop,
     })
   )
 
@@ -50,10 +51,8 @@ const useStudent = () => {
     totalSize?: number,
     last?: boolean
   ) => {
-    if (!students || !totalSize || !last) return
-
     dispatch(actions.resetStudents())
-    dispatch(actions.addStudents(students))
+    dispatch(actions.addStudents(students || []))
     dispatch(actions.setTotoalSize(totalSize))
     if (last) dispatch(actions.nextStop())
   }
@@ -63,6 +62,7 @@ const useStudent = () => {
     totalSize,
     refetchStudents,
     setStudentList,
+    nextStop,
   }
 }
 

--- a/packages/app/src/features/student/molecules/StudentList/index.tsx
+++ b/packages/app/src/features/student/molecules/StudentList/index.tsx
@@ -8,7 +8,7 @@ import * as S from './style'
 
 const StudentList = () => {
   const router = useRouter()
-  const { studentList, totalSize } = useStudent()
+  const { studentList, totalSize, nextStop } = useStudent()
   const { observe } = useScrollObserver()
   const { onShow } = useModal()
 
@@ -24,16 +24,17 @@ const StudentList = () => {
       </S.MaxCount>
 
       <S.Students>
-        {!studentList.length &&
-          Array(...Array(20)).map((_, idx) => (
-            <StudentCardSkeleton key={idx} />
-          ))}
         {studentList?.map((i) => (
           <StudentCard key={i.id} {...i} onClick={() => onClick(i.id)} />
         ))}
-      </S.Students>
 
-      <div ref={observe} />
+        {!nextStop &&
+          Array(...Array(10)).map((_, idx) => (
+            <div ref={idx === 0 ? observe : undefined} key={idx}>
+              <StudentCardSkeleton />
+            </div>
+          ))}
+      </S.Students>
     </S.Content>
   )
 }

--- a/packages/app/src/features/student/stores/studentListSlice.ts
+++ b/packages/app/src/features/student/stores/studentListSlice.ts
@@ -3,11 +3,12 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit'
 
 interface InitialState {
   studentList: StudentType[]
-  totalSize?: number
+  totalSize: number
 }
 
 const initialState: InitialState = {
   studentList: [],
+  totalSize: 0,
 }
 
 const studentListSlice = createSlice({
@@ -20,8 +21,8 @@ const studentListSlice = createSlice({
     resetStudents: (state) => {
       state.studentList = []
     },
-    setTotoalSize: (state, { payload }: PayloadAction<number>) => {
-      state.totalSize = payload
+    setTotoalSize: (state, { payload }: PayloadAction<number | undefined>) => {
+      state.totalSize = payload || 0
     },
   },
 })

--- a/packages/app/src/features/student/stores/studentParamSlice.ts
+++ b/packages/app/src/features/student/stores/studentParamSlice.ts
@@ -19,7 +19,7 @@ const initialState: InitialState = {
     techStacks: [],
     formOfEmployment: [],
   },
-  page: 1,
+  page: 2,
   size: 20,
   isLoading: false,
   isReady: false,

--- a/packages/shared/src/atoms/Skeleton/index.tsx
+++ b/packages/shared/src/atoms/Skeleton/index.tsx
@@ -27,7 +27,7 @@ interface TextProps {
 }
 
 export const SkeletonText = ({
-  width,
+  width = '100%',
   height = '1em',
   marginRight,
   marginBottom,

--- a/packages/shared/src/atoms/StudentCard/style.ts
+++ b/packages/shared/src/atoms/StudentCard/style.ts
@@ -78,6 +78,7 @@ export const UserInfo = styled.div`
   flex-direction: column;
   gap: 1rem;
   overflow: hidden;
+  width: 100%;
 
   @media (max-width: 41.5rem) {
     gap: 1.25rem;


### PR DESCRIPTION
## 💡 개요

학생이 20명을 넘으면 skeleton ui가 꺼지지 않는 문제를 발견했습니다

## 📃 작업내용

- 어떻게 코드를 지우고 수정을 하다보니 해결이 되었습니다
   - 정확히 뭐가 문제였는 지는 모르지만 알아 내면 적을 예정입니다
- 학생 리스트에서 맨 아래에 skeleton ui가 떠서 보일 때 다음 페이지 query를 날리 도록 수정했습니다