### PR TITLE
[#303] 회원가입 리렌더링 및 요청 문제 해결

### DIFF
--- a/packages/app/src/features/auth/hook/useLoggedIn.tsx
+++ b/packages/app/src/features/auth/hook/useLoggedIn.tsx
@@ -15,7 +15,12 @@ const useLoggedIn = ({ redirectTo, redirectToIfFound }: Props) => {
   useEffect(() => {
     if ((!redirectTo && isLoading) || (!redirectToIfFound && isLoading)) return
 
-    if (isSuccess && router.pathname === '/register' && !data.isExist) return
+    if (
+      isSuccess &&
+      !data.isExist &&
+      ['/register', '/register/teacher'].includes(router.pathname)
+    )
+      return
     if (isSuccess && !data.isExist) {
       if (data.role === 'ROLE_TEACHER') router.push('/register/teacher')
       else router.push('/register')

--- a/packages/app/src/features/register/services/PostTeacherRegisterService/index.tsx
+++ b/packages/app/src/features/register/services/PostTeacherRegisterService/index.tsx
@@ -9,7 +9,7 @@ const PostTeacherRegisterService = async (form: TeacherRegisterFormType) => {
   }
   try {
     await axiosApi.post(
-      `/server/${TeacherType}`,
+      `/server/teacher/${TeacherType}`,
       TeacherType === 'homeroom' ? teacherForm : null
     )
 

--- a/packages/app/src/pages/register/teacher.tsx
+++ b/packages/app/src/pages/register/teacher.tsx
@@ -4,8 +4,7 @@ import { TeacherRegisterForm } from '@features/register/organisms'
 import RegisterLayout from '@layouts/RegisterLayout'
 
 const TeacherRegister = () => {
-  useLoggedIn({ redirectTo: '/' })
-
+  useLoggedIn({ redirectTo: '/', redirectToIfFound: '/' })
   return (
     <>
       <SEO title='선생님 회원가입' />

--- a/packages/app/src/pages/register/teacher.tsx
+++ b/packages/app/src/pages/register/teacher.tsx
@@ -4,7 +4,7 @@ import { TeacherRegisterForm } from '@features/register/organisms'
 import RegisterLayout from '@layouts/RegisterLayout'
 
 const TeacherRegister = () => {
-  useLoggedIn({ redirectTo: '/', redirectToIfFound: '/' })
+  useLoggedIn({ redirectTo: '/' })
 
   return (
     <>


### PR DESCRIPTION
## 💡 배경 및 개요
+ 선생님 회원가입이 메인페이지 -> 선생님회원가입 -> 메인패이지 순으로 무한 페이지이동을 반복했습니다.
+ api의 주소가 잘못 입력되어 로그인의 기능을 하지 않았습니다.

Resolves: #303 

## 📃 작업내용
+ 메인페이지 이동을 방지했습니다.
+ api  주소를 수정했습니다.
## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
