### PR TITLE
[#337] hot reloader가 끊기는 문제 해결

### DIFF
--- a/.github/workflows/SMS-app-CI.yml
+++ b/.github/workflows/SMS-app-CI.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: 9.1.2
+          version: 9.4.0
 
       - run: |
           touch packages/app/.env.local

--- a/.github/workflows/SMS-shared-CI.yml
+++ b/.github/workflows/SMS-shared-CI.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: 9.1.2
+          version: 9.4.0
 
       - run: pnpm i --frozen-lockfile
       - run: pnpm build:shared

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sms",
   "version": "1.0.0",
   "private": true,
-  "packageManager": "pnpm@9.1.2",
+  "packageManager": "pnpm@9.4.0",
   "scripts": {
     "format": "prettier --check --cache **/*.{tsx,ts}",
     "eslint": "eslint --cache **/*.{tsx,ts}",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -21,7 +21,7 @@
     "file-saver": "^2.0.5",
     "jsonwebtoken": "^9.0.2",
     "lottie-web": "^5.12.2",
-    "next": "13.3.0",
+    "next": "13.5.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.43.9",

--- a/packages/app/src/features/auth/lib/setAuthCookies.ts
+++ b/packages/app/src/features/auth/lib/setAuthCookies.ts
@@ -1,10 +1,9 @@
 import { ReissueResponse } from '@features/auth/type/TokenResponse'
 import Token from '@lib/Token'
-import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies'
 import { NextApiRequest, NextApiResponse } from 'next'
 import Cookies from 'cookies'
 
-const cookieOption = (expires: string): Partial<ResponseCookie> => ({
+const cookieOption = (expires: string): Partial<Cookies.SetOption> => ({
   secure: process.env.NODE_ENV === 'production',
   httpOnly: true,
   expires: new Date(expires),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^17.5.1
-        version: 17.8.1(@swc/core@1.6.3(@swc/helpers@0.4.14))
+        version: 17.8.1(@swc/core@1.6.3(@swc/helpers@0.5.2))
       '@commitlint/config-conventional':
         specifier: ^17.4.4
         version: 17.8.1
@@ -31,7 +31,7 @@ importers:
         version: 7.6.19(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/nextjs':
         specifier: ^7.4.0
-        version: 7.6.19(@swc/core@1.6.3(@swc/helpers@0.4.14))(@swc/helpers@0.4.14)(esbuild@0.18.20)(next@13.3.0(@babel/core@7.24.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-hot-middleware@2.26.1)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+        version: 7.6.19(@swc/core@1.6.3(@swc/helpers@0.5.2))(@swc/helpers@0.5.2)(esbuild@0.18.20)(next@13.5.6(@babel/core@7.24.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-hot-middleware@2.26.1)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       '@storybook/react':
         specifier: ^7.4.0
         version: 7.6.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
@@ -123,8 +123,8 @@ importers:
         specifier: ^5.12.2
         version: 5.12.2
       next:
-        specifier: 13.3.0
-        version: 13.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 13.5.6
+        version: 13.5.6(@babel/core@7.24.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -1280,8 +1280,17 @@ packages:
   '@next/env@13.3.0':
     resolution: {integrity: sha512-AjppRV4uG3No7L1plinoTQETH+j2F10TEnrMfzbTUYwze5sBUPveeeBAPZPm8OkJZ1epq9OyYKhZrvbD6/9HCQ==}
 
+  '@next/env@13.5.6':
+    resolution: {integrity: sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw==}
+
   '@next/swc-darwin-arm64@13.3.0':
     resolution: {integrity: sha512-DmIQCNq6JtccLPPBzf0dgh2vzMWt5wjxbP71pCi5EWpWYE3MsP6FcRXi4MlAmFNDQOfcFXR2r7kBeG1LpZUh1w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-arm64@13.5.6':
+    resolution: {integrity: sha512-5nvXMzKtZfvcu4BhtV0KH1oGv4XEW+B+jOfmBdpFI3C7FrB/MfujRpWYSBBO64+qbW8pkZiSyQv9eiwnn5VIQA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -1292,8 +1301,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@next/swc-darwin-x64@13.5.6':
+    resolution: {integrity: sha512-6cgBfxg98oOCSr4BckWjLLgiVwlL3vlLj8hXg2b+nDgm4bC/qVXXLfpLB9FHdoDu4057hzywbxKvmYGmi7yUzA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@next/swc-linux-arm64-gnu@13.3.0':
     resolution: {integrity: sha512-Wzz2p/WqAJUqTVoLo6H18WMeAXo3i+9DkPDae4oQG8LMloJ3if4NEZTnOnTUlro6cq+S/W4pTGa97nWTrOjbGw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-gnu@13.5.6':
+    resolution: {integrity: sha512-txagBbj1e1w47YQjcKgSU4rRVQ7uF29YpnlHV5xuVUsgCUf2FmyfJ3CPjZUvpIeXCJAoMCFAoGnbtX86BK7+sg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1304,8 +1325,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@next/swc-linux-arm64-musl@13.5.6':
+    resolution: {integrity: sha512-cGd+H8amifT86ZldVJtAKDxUqeFyLWW+v2NlBULnLAdWsiuuN8TuhVBt8ZNpCqcAuoruoSWynvMWixTFcroq+Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@next/swc-linux-x64-gnu@13.3.0':
     resolution: {integrity: sha512-jOFlpGuPD7W2tuXVJP4wt9a3cpNxWAPcloq5EfMJRiXsBBOjLVFZA7boXYxEBzSVgUiVVr1V9T0HFM7pULJ1qA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@13.5.6':
+    resolution: {integrity: sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1316,8 +1349,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@next/swc-linux-x64-musl@13.5.6':
+    resolution: {integrity: sha512-CFHvP9Qz98NruJiUnCe61O6GveKKHpJLloXbDSWRhqhkJdZD2zU5hG+gtVJR//tyW897izuHpM6Gtf6+sNgJPQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@next/swc-win32-arm64-msvc@13.3.0':
     resolution: {integrity: sha512-OeHiA6YEvndxT46g+rzFK/MQTfftKxJmzslERMu9LDdC6Kez0bdrgEYed5eXFK2Z1viKZJCGRlhd06rBusyztA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-arm64-msvc@13.5.6':
+    resolution: {integrity: sha512-aFv1ejfkbS7PUa1qVPwzDHjQWQtknzAZWGTKYIAaS4NMtBlk3VyA6AYn593pqNanlicewqyl2jUhQAaFV/qXsg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -1328,8 +1373,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@next/swc-win32-ia32-msvc@13.5.6':
+    resolution: {integrity: sha512-XqqpHgEIlBHvzwG8sp/JXMFkLAfGLqkbVsyN+/Ih1mR8INb6YCc2x/Mbwi6hsAgUnqQztz8cvEbHJUbSl7RHDg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
   '@next/swc-win32-x64-msvc@13.3.0':
     resolution: {integrity: sha512-Reer6rkLLcoOvB0dd66+Y7WrWVFH7sEEkF/4bJCIfsSKnTStTYaHtwIJAwbqnt9I392Tqvku0KkoqZOryWV9LQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@13.5.6':
+    resolution: {integrity: sha512-Cqfe1YmOS7k+5mGu92nl5ULkzpKuxJrP3+4AEuPmrpFZ3BHxTY3TnHmU1On3bFmFFs6FbTcdF58CCUProGpIGQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2096,6 +2153,9 @@ packages:
 
   '@swc/helpers@0.4.14':
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
+
+  '@swc/helpers@0.5.2':
+    resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
 
   '@swc/types@0.1.8':
     resolution: {integrity: sha512-RNFA3+7OJFNYY78x0FYwi1Ow+iF1eF5WvmfY1nXPOEH4R2p/D4Cr1vzje7dNAI2aLFqpv8Wyz4oKSWqIZArpQA==}
@@ -4731,6 +4791,21 @@ packages:
       sass:
         optional: true
 
+  next@13.5.6:
+    resolution: {integrity: sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==}
+    engines: {node: '>=16.14.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      sass:
+        optional: true
+
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
@@ -5086,6 +5161,10 @@ packages:
 
   postcss@8.4.14:
     resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.4.38:
@@ -6198,6 +6277,10 @@ packages:
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
+  watchpack@2.4.0:
+    resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
+    engines: {node: '>=10.13.0'}
+
   watchpack@2.4.1:
     resolution: {integrity: sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==}
     engines: {node: '>=10.13.0'}
@@ -7276,11 +7359,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@17.8.1(@swc/core@1.6.3(@swc/helpers@0.4.14))':
+  '@commitlint/cli@17.8.1(@swc/core@1.6.3(@swc/helpers@0.5.2))':
     dependencies:
       '@commitlint/format': 17.8.1
       '@commitlint/lint': 17.8.1
-      '@commitlint/load': 17.8.1(@swc/core@1.6.3(@swc/helpers@0.4.14))
+      '@commitlint/load': 17.8.1(@swc/core@1.6.3(@swc/helpers@0.5.2))
       '@commitlint/read': 17.8.1
       '@commitlint/types': 17.8.1
       execa: 5.1.1
@@ -7329,7 +7412,7 @@ snapshots:
       '@commitlint/rules': 17.8.1
       '@commitlint/types': 17.8.1
 
-  '@commitlint/load@17.8.1(@swc/core@1.6.3(@swc/helpers@0.4.14))':
+  '@commitlint/load@17.8.1(@swc/core@1.6.3(@swc/helpers@0.5.2))':
     dependencies:
       '@commitlint/config-validator': 17.8.1
       '@commitlint/execute-rule': 17.8.1
@@ -7338,12 +7421,12 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.4.5)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.5))(ts-node@10.9.2(@swc/core@1.6.3(@swc/helpers@0.4.14))(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.5))(ts-node@10.9.2(@swc/core@1.6.3(@swc/helpers@0.5.2))(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.2(@swc/core@1.6.3(@swc/helpers@0.4.14))(@types/node@18.19.37)(typescript@5.4.5)
+      ts-node: 10.9.2(@swc/core@1.6.3(@swc/helpers@0.5.2))(@types/node@18.19.37)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@swc/core'
@@ -7715,31 +7798,60 @@ snapshots:
 
   '@next/env@13.3.0': {}
 
+  '@next/env@13.5.6': {}
+
   '@next/swc-darwin-arm64@13.3.0':
+    optional: true
+
+  '@next/swc-darwin-arm64@13.5.6':
     optional: true
 
   '@next/swc-darwin-x64@13.3.0':
     optional: true
 
+  '@next/swc-darwin-x64@13.5.6':
+    optional: true
+
   '@next/swc-linux-arm64-gnu@13.3.0':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@13.5.6':
     optional: true
 
   '@next/swc-linux-arm64-musl@13.3.0':
     optional: true
 
+  '@next/swc-linux-arm64-musl@13.5.6':
+    optional: true
+
   '@next/swc-linux-x64-gnu@13.3.0':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@13.5.6':
     optional: true
 
   '@next/swc-linux-x64-musl@13.3.0':
     optional: true
 
+  '@next/swc-linux-x64-musl@13.5.6':
+    optional: true
+
   '@next/swc-win32-arm64-msvc@13.3.0':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@13.5.6':
     optional: true
 
   '@next/swc-win32-ia32-msvc@13.3.0':
     optional: true
 
+  '@next/swc-win32-ia32-msvc@13.5.6':
+    optional: true
+
   '@next/swc-win32-x64-msvc@13.3.0':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@13.5.6':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -7757,7 +7869,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.37.1
@@ -7767,7 +7879,7 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.2.0
       source-map: 0.7.4
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
     optionalDependencies:
       type-fest: 2.19.0
       webpack-hot-middleware: 2.26.1
@@ -8346,7 +8458,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-webpack5@7.6.19(@swc/helpers@0.4.14)(esbuild@0.18.20)(typescript@5.4.5)':
+  '@storybook/builder-webpack5@7.6.19(@swc/helpers@0.5.2)(esbuild@0.18.20)(typescript@5.4.5)':
     dependencies:
       '@babel/core': 7.24.7
       '@storybook/channels': 7.6.19
@@ -8357,33 +8469,33 @@ snapshots:
       '@storybook/node-logger': 7.6.19
       '@storybook/preview': 7.6.19
       '@storybook/preview-api': 7.6.19
-      '@swc/core': 1.6.3(@swc/helpers@0.4.14)
+      '@swc/core': 1.6.3(@swc/helpers@0.5.2)
       '@types/node': 18.19.37
       '@types/semver': 7.5.8
-      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.3.1
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      css-loader: 6.11.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       es-module-lexer: 1.5.3
       express: 4.19.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.4.5)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.4.5)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      html-webpack-plugin: 5.6.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       magic-string: 0.30.10
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.2
-      style-loader: 3.3.4(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
-      swc-loader: 0.2.6(@swc/core@1.6.3(@swc/helpers@0.4.14))(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
-      terser-webpack-plugin: 5.3.10(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      style-loader: 3.3.4(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
+      swc-loader: 0.2.6(@swc/core@1.6.3(@swc/helpers@0.5.2))(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       ts-dedent: 2.2.0
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
-      webpack-dev-middleware: 6.1.3(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
+      webpack-dev-middleware: 6.1.3(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.5.0
     optionalDependencies:
@@ -8663,7 +8775,7 @@ snapshots:
 
   '@storybook/mdx2-csf@1.1.0': {}
 
-  '@storybook/nextjs@7.6.19(@swc/core@1.6.3(@swc/helpers@0.4.14))(@swc/helpers@0.4.14)(esbuild@0.18.20)(next@13.3.0(@babel/core@7.24.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-hot-middleware@2.26.1)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))':
+  '@storybook/nextjs@7.6.19(@swc/core@1.6.3(@swc/helpers@0.5.2))(@swc/helpers@0.5.2)(esbuild@0.18.20)(next@13.5.6(@babel/core@7.24.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-hot-middleware@2.26.1)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.24.7)
@@ -8679,39 +8791,39 @@ snapshots:
       '@babel/preset-typescript': 7.24.7(@babel/core@7.24.7)
       '@babel/runtime': 7.24.7
       '@storybook/addon-actions': 7.6.19
-      '@storybook/builder-webpack5': 7.6.19(@swc/helpers@0.4.14)(esbuild@0.18.20)(typescript@5.4.5)
+      '@storybook/builder-webpack5': 7.6.19(@swc/helpers@0.5.2)(esbuild@0.18.20)(typescript@5.4.5)
       '@storybook/core-common': 7.6.19
       '@storybook/core-events': 7.6.19
       '@storybook/node-logger': 7.6.19
-      '@storybook/preset-react-webpack': 7.6.19(@babel/core@7.24.7)(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-hot-middleware@2.26.1)
+      '@storybook/preset-react-webpack': 7.6.19(@babel/core@7.24.7)(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-hot-middleware@2.26.1)
       '@storybook/preview-api': 7.6.19
       '@storybook/react': 7.6.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
       '@types/node': 18.19.37
       '@types/semver': 7.5.8
-      css-loader: 6.11.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      css-loader: 6.11.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       find-up: 5.0.0
       fs-extra: 11.2.0
       image-size: 1.1.1
       loader-utils: 3.3.1
-      next: 13.3.0(@babel/core@7.24.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      next: 13.5.6(@babel/core@7.24.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       pnp-webpack-plugin: 1.7.0(typescript@5.4.5)
       postcss: 8.4.38
-      postcss-loader: 7.3.4(postcss@8.4.38)(typescript@5.4.5)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      postcss-loader: 7.3.4(postcss@8.4.38)(typescript@5.4.5)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       resolve-url-loader: 5.0.0
-      sass-loader: 12.6.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      sass-loader: 12.6.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       semver: 7.6.2
       sharp: 0.32.6
-      style-loader: 3.3.4(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      style-loader: 3.3.4(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       styled-jsx: 5.1.1(@babel/core@7.24.7)(react@18.2.0)
       ts-dedent: 2.2.0
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.1.0
     optionalDependencies:
       typescript: 5.4.5
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -8737,16 +8849,16 @@ snapshots:
 
   '@storybook/postinstall@7.6.19': {}
 
-  '@storybook/preset-react-webpack@7.6.19(@babel/core@7.24.7)(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-hot-middleware@2.26.1)':
+  '@storybook/preset-react-webpack@7.6.19(@babel/core@7.24.7)(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/preset-flow': 7.24.7(@babel/core@7.24.7)
       '@babel/preset-react': 7.24.7(@babel/core@7.24.7)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       '@storybook/core-webpack': 7.6.19
       '@storybook/docs-tools': 7.6.19
       '@storybook/node-logger': 7.6.19
       '@storybook/react': 7.6.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.4.5)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.4.5)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       '@types/node': 18.19.37
       '@types/semver': 7.5.8
       babel-plugin-add-react-displayname: 0.0.5
@@ -8757,7 +8869,7 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       react-refresh: 0.14.2
       semver: 7.6.2
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
     optionalDependencies:
       '@babel/core': 7.24.7
       typescript: 5.4.5
@@ -8794,7 +8906,7 @@ snapshots:
 
   '@storybook/preview@7.6.19': {}
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.4.5)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.4.5)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))':
     dependencies:
       debug: 4.3.5
       endent: 2.1.0
@@ -8804,7 +8916,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.4.5)
       tslib: 2.6.3
       typescript: 5.4.5
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
     transitivePeerDependencies:
       - supports-color
 
@@ -8916,7 +9028,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.6.3':
     optional: true
 
-  '@swc/core@1.6.3(@swc/helpers@0.4.14)':
+  '@swc/core@1.6.3(@swc/helpers@0.5.2)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.8
@@ -8931,11 +9043,15 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.6.3
       '@swc/core-win32-ia32-msvc': 1.6.3
       '@swc/core-win32-x64-msvc': 1.6.3
-      '@swc/helpers': 0.4.14
+      '@swc/helpers': 0.5.2
 
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.4.14':
+    dependencies:
+      tslib: 2.6.3
+
+  '@swc/helpers@0.5.2':
     dependencies:
       tslib: 2.6.3
 
@@ -9589,12 +9705,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.7
 
-  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)):
+  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)):
     dependencies:
       '@babel/core': 7.24.7
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
 
   babel-plugin-add-react-displayname@0.0.5: {}
 
@@ -10033,11 +10149,11 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.5))(ts-node@10.9.2(@swc/core@1.6.3(@swc/helpers@0.4.14))(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.5))(ts-node@10.9.2(@swc/core@1.6.3(@swc/helpers@0.5.2))(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@5.4.5)
-      ts-node: 10.9.2(@swc/core@1.6.3(@swc/helpers@0.4.14))(@types/node@18.19.37)(typescript@5.4.5)
+      ts-node: 10.9.2(@swc/core@1.6.3(@swc/helpers@0.5.2))(@types/node@18.19.37)(typescript@5.4.5)
       typescript: 5.4.5
 
   cosmiconfig@7.1.0:
@@ -10107,7 +10223,7 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
-  css-loader@6.11.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)):
+  css-loader@6.11.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -10118,7 +10234,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.2
     optionalDependencies:
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
 
   css-select@4.3.0:
     dependencies:
@@ -10922,7 +11038,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.4.5)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.4.5)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)):
     dependencies:
       '@babel/code-frame': 7.24.7
       chalk: 4.1.2
@@ -10937,7 +11053,7 @@ snapshots:
       semver: 7.6.2
       tapable: 2.2.1
       typescript: 5.4.5
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
 
   form-data@4.0.0:
     dependencies:
@@ -11198,7 +11314,7 @@ snapshots:
 
   html-tags@3.3.1: {}
 
-  html-webpack-plugin@5.6.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)):
+  html-webpack-plugin@5.6.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -11206,7 +11322,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -11930,26 +12046,27 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@13.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@13.5.6(@babel/core@7.24.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@next/env': 13.3.0
-      '@swc/helpers': 0.4.14
+      '@next/env': 13.5.6
+      '@swc/helpers': 0.5.2
       busboy: 1.6.0
       caniuse-lite: 1.0.30001636
-      postcss: 8.4.14
+      postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.7)(react@18.2.0)
+      watchpack: 2.4.0
     optionalDependencies:
-      '@next/swc-darwin-arm64': 13.3.0
-      '@next/swc-darwin-x64': 13.3.0
-      '@next/swc-linux-arm64-gnu': 13.3.0
-      '@next/swc-linux-arm64-musl': 13.3.0
-      '@next/swc-linux-x64-gnu': 13.3.0
-      '@next/swc-linux-x64-musl': 13.3.0
-      '@next/swc-win32-arm64-msvc': 13.3.0
-      '@next/swc-win32-ia32-msvc': 13.3.0
-      '@next/swc-win32-x64-msvc': 13.3.0
+      '@next/swc-darwin-arm64': 13.5.6
+      '@next/swc-darwin-x64': 13.5.6
+      '@next/swc-linux-arm64-gnu': 13.5.6
+      '@next/swc-linux-arm64-musl': 13.5.6
+      '@next/swc-linux-x64-gnu': 13.5.6
+      '@next/swc-linux-x64-musl': 13.5.6
+      '@next/swc-win32-arm64-msvc': 13.5.6
+      '@next/swc-win32-ia32-msvc': 13.5.6
+      '@next/swc-win32-x64-msvc': 13.5.6
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -11979,7 +12096,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -12006,7 +12123,7 @@ snapshots:
       url: 0.11.3
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
 
   node-releases@2.0.14: {}
 
@@ -12299,13 +12416,13 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-loader@7.3.4(postcss@8.4.38)(typescript@5.4.5)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)):
+  postcss-loader@7.3.4(postcss@8.4.38)(typescript@5.4.5)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.4.5)
       jiti: 1.21.6
       postcss: 8.4.38
       semver: 7.6.2
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
     transitivePeerDependencies:
       - typescript
 
@@ -12338,6 +12455,12 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.14:
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.1
+      source-map-js: 1.2.0
+
+  postcss@8.4.31:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.0.1
@@ -12824,11 +12947,11 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@12.6.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)):
+  sass-loader@12.6.0(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)):
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
 
   scheduler@0.23.2:
     dependencies:
@@ -13125,9 +13248,9 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  style-loader@3.3.4(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)):
+  style-loader@3.3.4(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)):
     dependencies:
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
 
   styled-jsx@5.1.1(@babel/core@7.24.7)(react@18.2.0):
     dependencies:
@@ -13135,11 +13258,6 @@ snapshots:
       react: 18.2.0
     optionalDependencies:
       '@babel/core': 7.24.7
-
-  styled-jsx@5.1.1(react@18.2.0):
-    dependencies:
-      client-only: 0.0.1
-      react: 18.2.0
 
   stylis@4.2.0: {}
 
@@ -13157,11 +13275,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swc-loader@0.2.6(@swc/core@1.6.3(@swc/helpers@0.4.14))(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)):
+  swc-loader@0.2.6(@swc/core@1.6.3(@swc/helpers@0.5.2))(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)):
     dependencies:
-      '@swc/core': 1.6.3(@swc/helpers@0.4.14)
+      '@swc/core': 1.6.3(@swc/helpers@0.5.2)
       '@swc/counter': 0.1.3
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
 
   synchronous-promise@2.0.17: {}
 
@@ -13223,16 +13341,16 @@ snapshots:
       type-fest: 0.16.0
       unique-string: 2.0.0
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.1
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
     optionalDependencies:
-      '@swc/core': 1.6.3(@swc/helpers@0.4.14)
+      '@swc/core': 1.6.3(@swc/helpers@0.5.2)
       esbuild: 0.18.20
 
   terser@5.31.1:
@@ -13293,7 +13411,7 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-node@10.9.2(@swc/core@1.6.3(@swc/helpers@0.4.14))(@types/node@18.19.37)(typescript@5.4.5):
+  ts-node@10.9.2(@swc/core@1.6.3(@swc/helpers@0.5.2))(@types/node@18.19.37)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -13311,7 +13429,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.6.3(@swc/helpers@0.4.14)
+      '@swc/core': 1.6.3(@swc/helpers@0.5.2)
 
   ts-pnp@1.2.0(typescript@5.4.5):
     optionalDependencies:
@@ -13555,6 +13673,11 @@ snapshots:
     dependencies:
       makeerror: 1.0.12
 
+  watchpack@2.4.0:
+    dependencies:
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+
   watchpack@2.4.1:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -13581,7 +13704,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@6.1.3(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)):
+  webpack-dev-middleware@6.1.3(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -13589,7 +13712,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)
+      webpack: 5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -13603,7 +13726,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20):
+  webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -13626,7 +13749,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.4.14))(esbuild@0.18.20))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20)(webpack@5.92.1(@swc/core@1.6.3(@swc/helpers@0.5.2))(esbuild@0.18.20))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
## 💡 배경 및 개요

- POST 요청을 next server에 보내면 hot reloader가 죽고 브라우저와 nextjs 개발섭과의 통신이 끊어지는 문제를 발견했습니다

Resolves: #337

## 📃 작업내용

- nextjs 버전을 13.3.0에서 13.5.6으로 마이그레이션했습니다
- 추가로 타입 에러 때문에 cookie option 타입을 수정하는 작업을 진행했습니다

## 🎸 기타

[참고 링크](https://github.com/vercel/next.js/pull/48039)