### PR TITLE
[#357] 학생 리스트 페이지 버그 수정

### DIFF
--- a/packages/app/src/features/student/queries/useStudentDetailQuery.tsx
+++ b/packages/app/src/features/student/queries/useStudentDetailQuery.tsx
@@ -7,9 +7,10 @@ interface Props {
 
 const useStudentDetailQuery = ({ studentId }: Props) => {
   return useQuery({
-    queryKey: ['studentDetail'],
+    queryKey: ['studentDetail', studentId],
     queryFn: () => studentDetailApi(studentId as string),
     enabled: typeof studentId === 'string',
+    placeholderData: (data) => data,
   })
 }
 

--- a/packages/shared/src/atoms/StudentCard/index.tsx
+++ b/packages/shared/src/atoms/StudentCard/index.tsx
@@ -41,7 +41,7 @@ const StudentCard = ({
 
       <S.UserInfo>
         <div>
-          <S.Name>{name}</S.Name>
+          <S.Name>{name.replace('**', '소금')}</S.Name>
           <S.Stack>{major}</S.Stack>
         </div>
 


### PR DESCRIPTION
## 💡 배경 및 개요

- 학생 이름 변경 `변**` -> `변소금`
- 학생 detail 페이지 문제 해결
   - 디테일 페이지의 학생 정보가 초기화 되지 않는 문제를 해결했습니다

Resolves: #357

## 📃 작업내용

- 학생 정보 조회 props 값 수정
- 리스트 페이지의 학생 이름 수정